### PR TITLE
CU-868ex18rd Locking macos build agent version

### DIFF
--- a/.github/workflows/react-native-cicd.yml
+++ b/.github/workflows/react-native-cicd.yml
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         platform: [android, ios]
-    runs-on: ${{ matrix.platform == 'ios' && 'macos-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.platform == 'ios' && 'macos-14' || 'ubuntu-latest' }}
     environment: RNBuild
     steps:
       - name: 🏗 Checkout repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the iOS build environment in CI to use macOS 14, aligning with current Apple tooling and ensuring compatibility with the latest runners.
  * Maintains existing build and deploy logic; only the underlying runner version changes.
  * No impact on app features or user experience; this is an infrastructure update aimed at build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->