### PR TITLE
RR-T43 Security and Bug fix pass

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -104,6 +104,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       'android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE',
       'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
     ],
+    blockedPermissions: ['android.permission.READ_MEDIA_IMAGES', 'android.permission.READ_MEDIA_VIDEO'],
   },
   web: {
     favicon: './assets/favicon.png',

--- a/customManifest.plugin.js
+++ b/customManifest.plugin.js
@@ -13,6 +13,9 @@ const withForegroundService = (config) => {
     // Allow cleartext HTTP traffic for dev server connectivity (required for targetSdk 35+)
     mainApplication.$['android:usesCleartextTraffic'] = 'true';
 
+    // Disable adb/cloud backup of app data (PII, tokens)
+    mainApplication.$['android:allowBackup'] = 'false';
+
     mainApplication['service'] = mainApplication['service'] || [];
     mainApplication['service'].push({
       $: {

--- a/env.js
+++ b/env.js
@@ -94,7 +94,6 @@ const client = z.object({
   LOGGING_KEY: z.string(),
   APP_KEY: z.string(),
   RESPOND_MAPBOX_PUBKEY: z.string(),
-  RESPOND_MAPBOX_DLKEY: z.string(),
   IS_MOBILE_APP: z.boolean(),
   SENTRY_DSN: z.string(),
   COUNTLY_URL: z.string(),
@@ -107,6 +106,7 @@ const buildTime = z.object({
   EAS_PROJECT_ID: z.string(),
   IOS_APP_GROUP: z.string(),
   IOS_APPLE_TEAM_ID: z.string().optional(),
+  RESPOND_MAPBOX_DLKEY: z.string(),
   // ADD YOUR BUILD TIME ENV VARS HERE
 });
 
@@ -133,7 +133,6 @@ const _clientEnv = {
   APP_KEY: process.env.RESPOND_APP_KEY || '',
   IS_MOBILE_APP: true, // or whatever default you want
   RESPOND_MAPBOX_PUBKEY: process.env.RESPOND_MAPBOX_PUBKEY || '',
-  RESPOND_MAPBOX_DLKEY: process.env.RESPOND_MAPBOX_DLKEY || '',
   SENTRY_DSN: process.env.RESPOND_SENTRY_DSN || '',
   COUNTLY_APP_KEY: process.env.RESPOND_COUNTLY_APP_KEY || '',
   COUNTLY_URL: process.env.RESPOND_COUNTLY_URL || '',
@@ -148,6 +147,7 @@ const _buildTimeEnv = {
   EAS_PROJECT_ID,
   IOS_APP_GROUP: getIosAppGroup(),
   IOS_APPLE_TEAM_ID: process.env.IOS_APPLE_TEAM_ID || process.env.EXPO_APPLE_TEAM_ID || process.env.APPLE_TEAM_ID,
+  RESPOND_MAPBOX_DLKEY: process.env.RESPOND_MAPBOX_DLKEY || '',
   // ADD YOUR ENV VARS HERE TOO
 };
 

--- a/src/app/(app)/__tests__/calendar.test.tsx
+++ b/src/app/(app)/__tests__/calendar.test.tsx
@@ -263,9 +263,12 @@ describe('CalendarScreen', () => {
   const mockTrackEvent = jest.fn();
   const mockUseAnalytics = useAnalytics as jest.MockedFunction<typeof useAnalytics>;
 
+  const setCalendarStoreMock = (state: unknown) =>
+    (useCalendarStore as unknown as jest.Mock).mockImplementation((selector?: (s: unknown) => unknown) => (selector ? selector(state) : state));
+
   beforeEach(() => {
     (useTranslation as jest.Mock).mockReturnValue({ t: mockT });
-    (useCalendarStore as unknown as jest.Mock).mockReturnValue(mockStore);
+    setCalendarStoreMock(mockStore);
 
     // Default mock for analytics
     mockUseAnalytics.mockReturnValue({
@@ -352,7 +355,7 @@ describe('CalendarScreen', () => {
     });
 
     it('shows loading state for today\'s items', () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         isTodaysLoading: true,
       });
@@ -363,7 +366,7 @@ describe('CalendarScreen', () => {
     });
 
     it('shows error state for today\'s items', () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         error: 'Failed to load',
       });
@@ -393,7 +396,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-15T16:00:00Z',
       };
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [todayItem],
       });
@@ -414,7 +417,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-15T16:00:00Z',
       }));
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: multipleItems,
       });
@@ -452,7 +455,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-16T16:00:00Z',
       };
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [todayItem], // Should only contain today's item
       });
@@ -485,7 +488,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-15T10:30:00Z',
       };
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [todayItemUTC, todayItemPST],
       });
@@ -510,7 +513,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-16T07:00:00Z',
       };
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [todayItem],
       });
@@ -533,7 +536,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-16T04:00:00Z',
       };
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [], // Should be empty since no items are today
       });
@@ -546,7 +549,7 @@ describe('CalendarScreen', () => {
 
   describe('Upcoming Tab', () => {
     it('shows loading state for upcoming items', () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         isUpcomingLoading: true,
       });
@@ -566,7 +569,7 @@ describe('CalendarScreen', () => {
     });
 
     it('renders upcoming items when available', () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         upcomingCalendarItems: [mockCalendarItem],
       });
@@ -588,7 +591,7 @@ describe('CalendarScreen', () => {
         EndUtc: `2024-01-${16 + index}T16:00:00Z`,
       }));
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         upcomingCalendarItems: multipleUpcomingItems,
       });
@@ -642,7 +645,7 @@ describe('CalendarScreen', () => {
         StartUtc: '2024-01-16T14:00:00Z', // Keep for completeness
         End: '2024-01-16T16:00:00Z',
         EndUtc: '2024-01-16T16:00:00Z',
-      }; (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      }; setCalendarStoreMock({
         ...mockStore,
         selectedDate: testDate,
         selectedMonthItems: [todayItem, otherDayItem],
@@ -691,7 +694,7 @@ describe('CalendarScreen', () => {
         EndUtc: '2024-01-16T11:00:00Z',
       };
 
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         selectedDate: testDate,
         selectedMonthItems: [utcItem, pstItem, nextDayItem],
@@ -707,7 +710,7 @@ describe('CalendarScreen', () => {
     });
 
     it('shows empty message when no events for selected date', () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         selectedDate: '2024-01-15',
         selectedMonthItems: [],
@@ -722,7 +725,7 @@ describe('CalendarScreen', () => {
 
   describe('Calendar Item Details', () => {
     it('opens details sheet when item is pressed', async () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [mockCalendarItem],
       });
@@ -749,7 +752,7 @@ describe('CalendarScreen', () => {
     });
 
     it('closes details sheet when close is pressed', async () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [mockCalendarItem],
       });
@@ -774,7 +777,7 @@ describe('CalendarScreen', () => {
 
   describe('Error Handling', () => {
     it('calls retry action when retry button is pressed', () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         error: 'Network error',
       });
@@ -822,7 +825,7 @@ describe('CalendarScreen', () => {
     });
 
     it('tracks item interactions', async () => {
-      (useCalendarStore as unknown as jest.Mock).mockReturnValue({
+      setCalendarStoreMock({
         ...mockStore,
         todayCalendarItems: [mockCalendarItem],
       });

--- a/src/app/(app)/__tests__/map.test.tsx
+++ b/src/app/(app)/__tests__/map.test.tsx
@@ -289,14 +289,20 @@ jest.mock('@/stores/app/core-store', () => ({
   })),
 }));
 
-jest.mock('@/stores/app/location-store', () => ({
-  useLocationStore: jest.fn(() => ({
+jest.mock('@/stores/app/location-store', () => {
+  let mockState = {
     latitude: 40.7128,
     longitude: -74.006,
     heading: 90,
     isMapLocked: false,
-  })),
-}));
+  };
+  return {
+    useLocationStore: jest.fn((selector: any) => selector(mockState)),
+    __setMockState: (newState: any) => {
+      mockState = newState;
+    },
+  };
+});
 
 jest.mock('@/stores/toast/store', () => ({
   useToastStore: {
@@ -387,7 +393,7 @@ describe('HomeMap', () => {
 
   it('shows recenter button when user has moved map and location is available', async () => {
     const mockLocationStore = jest.requireMock('@/stores/app/location-store') as any;
-    mockLocationStore.useLocationStore.mockReturnValue({
+    mockLocationStore.__setMockState({
       latitude: 40.7128,
       longitude: -74.006,
       heading: 90,
@@ -412,7 +418,7 @@ describe('HomeMap', () => {
 
   it('does not show recenter button when map is locked', async () => {
     const mockLocationStore = jest.requireMock('@/stores/app/location-store') as any;
-    mockLocationStore.useLocationStore.mockReturnValue({
+    mockLocationStore.__setMockState({
       latitude: 40.7128,
       longitude: -74.006,
       heading: 90,
@@ -554,7 +560,7 @@ describe('HomeMap', () => {
   describe('Analytics Tracking', () => {
     it('tracks map view on focus', async () => {
       const mockLocationStore = jest.requireMock('@/stores/app/location-store') as any;
-      mockLocationStore.useLocationStore.mockReturnValue({
+      mockLocationStore.__setMockState({
         latitude: 40.7128,
         longitude: -74.006,
         heading: 90,
@@ -600,7 +606,7 @@ describe('HomeMap', () => {
 
     it('tracks recenter map action', async () => {
       const mockLocationStore = jest.requireMock('@/stores/app/location-store') as any;
-      mockLocationStore.useLocationStore.mockReturnValue({
+      mockLocationStore.__setMockState({
         latitude: 40.7128,
         longitude: -74.006,
         heading: 90,
@@ -685,7 +691,7 @@ describe('HomeMap', () => {
 
     it('tracks analytics with correct location data when location is unavailable', async () => {
       const mockLocationStore = jest.requireMock('@/stores/app/location-store') as any;
-      mockLocationStore.useLocationStore.mockReturnValue({
+      mockLocationStore.__setMockState({
         latitude: null,
         longitude: null,
         heading: null,
@@ -709,7 +715,7 @@ describe('HomeMap', () => {
 
     it('tracks analytics with map locked state', async () => {
       const mockLocationStore = jest.requireMock('@/stores/app/location-store') as any;
-      mockLocationStore.useLocationStore.mockReturnValue({
+      mockLocationStore.__setMockState({
         latitude: 40.7128,
         longitude: -74.006,
         heading: 90,

--- a/src/app/(app)/__tests__/messages.test.tsx
+++ b/src/app/(app)/__tests__/messages.test.tsx
@@ -427,8 +427,14 @@ const mockStore = {
 const mockedUseMessagesStore = useMessagesStore as jest.MockedFunction<typeof useMessagesStore>;
 const mockedUseSecurityStore = useSecurityStore as jest.MockedFunction<typeof useSecurityStore>;
 const mockUseAnalytics = useAnalytics as jest.MockedFunction<typeof useAnalytics>;
+let currentMessagesStore: unknown = mockStore;
 // Add getState method to the mocked store
-(mockedUseMessagesStore as any).getState = jest.fn(() => mockStore);
+(mockedUseMessagesStore as any).getState = jest.fn(() => currentMessagesStore);
+
+const setMessagesStoreMock = (state: unknown) => {
+  currentMessagesStore = state;
+  mockedUseMessagesStore.mockImplementation(((selector?: (s: unknown) => unknown) => (selector ? selector(state) : state)) as any);
+};
 
 const mockSecurityStore = {
   error: null,
@@ -452,7 +458,7 @@ describe('MessagesScreen', () => {
     mockTrackEvent.mockReset();
     mockTrackEvent.mockReset();
     mockTrackEvent.mockReset();
-    mockedUseMessagesStore.mockReturnValue(mockStore);
+    setMessagesStoreMock(mockStore);
     mockedUseSecurityStore.mockReturnValue(mockSecurityStore);
     mockUseAnalytics.mockReturnValue({
       trackEvent: mockTrackEvent,
@@ -478,7 +484,7 @@ describe('MessagesScreen', () => {
   });
 
   it('shows loading state when loading', () => {
-    mockedUseMessagesStore.mockReturnValue({
+    setMessagesStoreMock({
       ...mockStore,
       isLoading: true,
       getFilteredMessages: jest.fn(() => []),
@@ -490,7 +496,7 @@ describe('MessagesScreen', () => {
   });
 
   it('shows zero state when no messages', () => {
-    mockedUseMessagesStore.mockReturnValue({
+    setMessagesStoreMock({
       ...mockStore,
       getFilteredMessages: jest.fn(() => []),
     });
@@ -502,7 +508,7 @@ describe('MessagesScreen', () => {
   });
 
   it('shows error state when there is an error', () => {
-    mockedUseMessagesStore.mockReturnValue({
+    setMessagesStoreMock({
       ...mockStore,
       error: 'Failed to load messages',
     });
@@ -577,7 +583,7 @@ describe('MessagesScreen', () => {
     });
 
     it('shows send first message button in zero state when user can create messages', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         getFilteredMessages: jest.fn(() => []),
       });
@@ -592,7 +598,7 @@ describe('MessagesScreen', () => {
     });
 
     it('hides send first message button in zero state when user cannot create messages', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         getFilteredMessages: jest.fn(() => []),
       });
@@ -607,7 +613,7 @@ describe('MessagesScreen', () => {
     });
 
     it('hides compose FAB when in selection mode even if user can create messages', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         selectedForDeletion: new Set(['1']),
         hasSelectedMessages: jest.fn(() => true),
@@ -641,7 +647,7 @@ describe('MessagesScreen', () => {
     });
 
     it('calls openCompose when send first message button is pressed and user has permission', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         getFilteredMessages: jest.fn(() => []),
       });
@@ -671,7 +677,7 @@ describe('MessagesScreen', () => {
     });
 
     it('hides send first message button when permissions have not been loaded yet (undefined)', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         getFilteredMessages: jest.fn(() => []),
       });
@@ -730,7 +736,7 @@ describe('MessagesScreen', () => {
     });
 
     it('tracks compose opened from zero state', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         getFilteredMessages: jest.fn(() => []),
       });
@@ -803,7 +809,7 @@ describe('MessagesScreen', () => {
     });
 
     it('tracks retry button press', () => {
-      mockedUseMessagesStore.mockReturnValue({
+      setMessagesStoreMock({
         ...mockStore,
         error: 'Network error',
       });

--- a/src/app/(app)/__tests__/protocols.test.tsx
+++ b/src/app/(app)/__tests__/protocols.test.tsx
@@ -31,11 +31,7 @@ const mockProtocolsStore = {
 };
 
 jest.mock('@/stores/protocols/store', () => ({
-  useProtocolsStore: () => mockProtocolsStore,
-}));
-
-jest.mock('@/stores/protocols/store', () => ({
-  useProtocolsStore: () => mockProtocolsStore,
+  useProtocolsStore: (selector?: (state: typeof mockProtocolsStore) => unknown) => (selector ? selector(mockProtocolsStore) : mockProtocolsStore),
 }));
 
 // Mock react-native-svg first

--- a/src/app/(app)/__tests__/shifts.test.tsx
+++ b/src/app/(app)/__tests__/shifts.test.tsx
@@ -277,6 +277,9 @@ jest.mock('@/components/ui/icon', () => {
 const mockUseShiftsStore = useShiftsStore as jest.MockedFunction<typeof useShiftsStore>;
 const mockUseAnalytics = useAnalytics as jest.MockedFunction<typeof useAnalytics>;
 
+const setShiftsStoreMock = (state: unknown) =>
+  mockUseShiftsStore.mockImplementation(((selector?: (s: unknown) => unknown) => (selector ? selector(state) : state)) as any);
+
 const mockShifts = [
   {
     ShiftId: '1',
@@ -358,7 +361,7 @@ describe('ShiftsScreen', () => {
       trackEvent: mockTrackEvent,
     });
 
-    mockUseShiftsStore.mockReturnValue(defaultMockStore);
+    setShiftsStoreMock(defaultMockStore);
   });
 
   it('renders correctly with default state', () => {
@@ -371,7 +374,7 @@ describe('ShiftsScreen', () => {
 
   it('switches between today and all shifts views', () => {
     const setCurrentView = jest.fn();
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       setCurrentView,
     });
@@ -383,7 +386,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('shows all shifts when view is set to all', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       currentView: 'all',
     });
@@ -396,7 +399,7 @@ describe('ShiftsScreen', () => {
 
   it('handles search input correctly', () => {
     const setSearchQuery = jest.fn();
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       setSearchQuery,
     });
@@ -410,7 +413,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('shows loading state for today shifts', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       isTodaysLoading: true,
       todaysShiftDays: [],
@@ -422,7 +425,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('shows loading state for all shifts', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       currentView: 'all',
       isLoading: true,
@@ -435,7 +438,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('shows zero state when no shifts available', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       currentView: 'all',
       shifts: [],
@@ -447,7 +450,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('shows zero state when no today shifts available', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       todaysShiftDays: [],
     });
@@ -459,7 +462,7 @@ describe('ShiftsScreen', () => {
 
   it('calls fetchTodaysShifts on mount when in today view', async () => {
     const fetchTodaysShifts = jest.fn();
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       fetchTodaysShifts,
     });
@@ -473,7 +476,7 @@ describe('ShiftsScreen', () => {
 
   it('calls fetchAllShifts when switching to all view', async () => {
     const fetchAllShifts = jest.fn();
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       currentView: 'all',
       fetchAllShifts,
@@ -487,7 +490,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('opens shift details sheet when shift is selected', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       isShiftDetailsOpen: true,
     });
@@ -498,7 +501,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('opens shift day details sheet when shift day is selected', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       isShiftDayDetailsOpen: true,
     });
@@ -523,7 +526,7 @@ describe('ShiftsScreen', () => {
 
   it('handles pull to refresh for today view', async () => {
     const fetchTodaysShifts = jest.fn();
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       fetchTodaysShifts,
     });
@@ -537,7 +540,7 @@ describe('ShiftsScreen', () => {
 
   it('handles pull to refresh for all shifts view', async () => {
     const fetchAllShifts = jest.fn();
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       currentView: 'all',
       fetchAllShifts,
@@ -549,7 +552,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('filters results based on search query', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       currentView: 'all',
       searchQuery: 'day',
@@ -563,7 +566,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('filters today shifts based on search query', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       searchQuery: 'day',
       todaysShiftDays: mockTodaysShifts.filter(shift =>
@@ -577,7 +580,7 @@ describe('ShiftsScreen', () => {
   });
 
   it('handles empty search results', () => {
-    mockUseShiftsStore.mockReturnValue({
+    setShiftsStoreMock({
       ...defaultMockStore,
       searchQuery: 'nonexistent',
       todaysShiftDays: [],
@@ -633,7 +636,7 @@ describe('ShiftsScreen', () => {
 
     it('tracks refresh actions', async () => {
       const fetchTodaysShifts = jest.fn();
-      mockUseShiftsStore.mockReturnValue({
+      setShiftsStoreMock({
         ...defaultMockStore,
         fetchTodaysShifts,
       });
@@ -657,7 +660,7 @@ describe('ShiftsScreen', () => {
 
     it('tracks shift selection in today view', () => {
       const selectShift = jest.fn();
-      mockUseShiftsStore.mockReturnValue({
+      setShiftsStoreMock({
         ...defaultMockStore,
         currentView: 'all',
         selectShift,
@@ -681,7 +684,7 @@ describe('ShiftsScreen', () => {
 
     it('tracks shift day selection in today view', () => {
       const selectShiftDay = jest.fn();
-      mockUseShiftsStore.mockReturnValue({
+      setShiftsStoreMock({
         ...defaultMockStore,
         selectShiftDay,
       });
@@ -703,7 +706,7 @@ describe('ShiftsScreen', () => {
     });
 
     it('tracks analytics with search query state', () => {
-      mockUseShiftsStore.mockReturnValue({
+      setShiftsStoreMock({
         ...defaultMockStore,
         searchQuery: 'day shift',
       });
@@ -719,7 +722,7 @@ describe('ShiftsScreen', () => {
     });
 
     it('tracks analytics for all shifts view', () => {
-      mockUseShiftsStore.mockReturnValue({
+      setShiftsStoreMock({
         ...defaultMockStore,
         currentView: 'all',
       });

--- a/src/app/(app)/__tests__/units.test.tsx
+++ b/src/app/(app)/__tests__/units.test.tsx
@@ -19,6 +19,7 @@ jest.mock('react-native/Libraries/Utilities/Appearance', () => ({
 // Mock the units store
 const mockUnitsStore = {
   units: [],
+  unitTypeStatuses: [],
   searchQuery: '',
   selectedFilters: [],
   setSearchQuery: jest.fn(),
@@ -29,7 +30,7 @@ const mockUnitsStore = {
 };
 
 jest.mock('@/stores/units/store', () => ({
-  useUnitsStore: () => mockUnitsStore,
+  useUnitsStore: (selector?: (state: typeof mockUnitsStore) => unknown) => (selector ? selector(mockUnitsStore) : mockUnitsStore),
 }));
 
 // Mock the analytics hook

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -41,9 +41,11 @@ import { useShiftsStore } from '@/stores/shifts/store';
 import { useSignalRStore } from '@/stores/signalr/signalr-store';
 import { useWeatherAlertsStore } from '@/stores/weather-alerts/weather-alerts-store';
 
+Mapbox.setAccessToken(Env.RESPOND_MAPBOX_PUBKEY);
+
 export default function TabLayout() {
   const { t } = useTranslation();
-  const { status } = useAuthStore();
+  const status = useAuthStore((state) => state.status);
   const [isFirstTime, _setIsFirstTime] = useIsFirstTime();
   const [isOpen, setIsOpen] = React.useState(false);
   const [isNotificationsOpen, setIsNotificationsOpen] = React.useState(false);
@@ -66,8 +68,6 @@ export default function TabLayout() {
 
   // Initialize push notifications
   usePushNotifications();
-
-  Mapbox.setAccessToken(Env.RESPOND_MAPBOX_PUBKEY);
 
   const initializeApp = useCallback(async () => {
     if (isInitializing.current) {
@@ -101,24 +101,36 @@ export default function TabLayout() {
       //await usePersonnelStore.getState().init();
       await securityStore.getState().getRights();
 
-      // Initialize weather alerts
-      await useWeatherAlertsStore.getState().fetchSettings();
-      const weatherSettings = useWeatherAlertsStore.getState().settings;
-      if (weatherSettings?.WeatherAlertsEnabled) {
-        await useWeatherAlertsStore.getState().fetchActiveAlerts();
-      }
-
       //await useSignalRStore.getState().connectUpdateHub();
       //await useSignalRStore.getState().connectGeolocationHub();
 
       hasInitialized.current = true;
 
-      // Initialize Bluetooth service
-      await bluetoothAudioService.initialize();
-      await audioService.initialize();
+      const independentInits: [string, () => Promise<unknown>][] = [
+        [
+          'weather alerts',
+          async () => {
+            await useWeatherAlertsStore.getState().fetchSettings();
+            const weatherSettings = useWeatherAlertsStore.getState().settings;
+            if (weatherSettings?.WeatherAlertsEnabled) {
+              await useWeatherAlertsStore.getState().fetchActiveAlerts();
+            }
+          },
+        ],
+        ['bluetooth audio service', () => bluetoothAudioService.initialize()],
+        ['audio service', () => audioService.initialize()],
+        ['offline queue service', () => offlineQueueService.initialize()],
+      ];
 
-      // Initialize offline queue service
-      await offlineQueueService.initialize();
+      const results = await Promise.allSettled(independentInits.map(([, init]) => init()));
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          logger.error({
+            message: `Failed to initialize ${independentInits[index]?.[0] ?? 'service'}`,
+            context: { error: result.reason },
+          });
+        }
+      });
 
       // Start location tracking when user is logged in
       try {
@@ -345,11 +357,7 @@ const CreateNotificationButton = ({
     return null;
   }
 
-  return (
-    <NovuProvider subscriberId={`${departmentCode}_User_${userId}`} applicationIdentifier={config.NovuApplicationId} backendUrl={config.NovuBackendApiUrl} socketUrl={config.NovuSocketUrl}>
-      <NotificationButton onPress={() => setIsNotificationsOpen(true)} />
-    </NovuProvider>
-  );
+  return <NotificationButton onPress={() => setIsNotificationsOpen(true)} />;
 };
 
 const styles = StyleSheet.create({

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -353,11 +353,15 @@ const CreateNotificationButton = ({
   userId: string | null;
   departmentCode: string | undefined;
 }) => {
+  const handlePress = useCallback(() => {
+    setIsNotificationsOpen(true);
+  }, [setIsNotificationsOpen]);
+
   if (!userId || !config || !config.NovuApplicationId || !config.NovuBackendApiUrl || !config.NovuSocketUrl || !departmentCode) {
     return null;
   }
 
-  return <NotificationButton onPress={() => setIsNotificationsOpen(true)} />;
+  return <NotificationButton onPress={handlePress} />;
 };
 
 const styles = StyleSheet.create({

--- a/src/app/(app)/calendar.tsx
+++ b/src/app/(app)/calendar.tsx
@@ -31,21 +31,19 @@ export default function CalendarScreen() {
   const [selectedItem, setSelectedItem] = useState<CalendarItemResultData | null>(null);
   const [isDetailsSheetOpen, setIsDetailsSheetOpen] = useState(false);
 
-  const {
-    todayCalendarItems,
-    upcomingCalendarItems,
-    selectedMonthItems,
-    selectedDate,
-    isTodaysLoading,
-    isUpcomingLoading,
-    isLoading,
-    error,
-    loadTodaysCalendarItems,
-    loadUpcomingCalendarItems,
-    loadCalendarItemsForDateRange,
-    viewCalendarItemAction,
-    clearError,
-  } = useCalendarStore();
+  const todayCalendarItems = useCalendarStore((state) => state.todayCalendarItems);
+  const upcomingCalendarItems = useCalendarStore((state) => state.upcomingCalendarItems);
+  const selectedMonthItems = useCalendarStore((state) => state.selectedMonthItems);
+  const selectedDate = useCalendarStore((state) => state.selectedDate);
+  const isTodaysLoading = useCalendarStore((state) => state.isTodaysLoading);
+  const isUpcomingLoading = useCalendarStore((state) => state.isUpcomingLoading);
+  const isLoading = useCalendarStore((state) => state.isLoading);
+  const error = useCalendarStore((state) => state.error);
+  const loadTodaysCalendarItems = useCalendarStore((state) => state.loadTodaysCalendarItems);
+  const loadUpcomingCalendarItems = useCalendarStore((state) => state.loadUpcomingCalendarItems);
+  const loadCalendarItemsForDateRange = useCalendarStore((state) => state.loadCalendarItemsForDateRange);
+  const viewCalendarItemAction = useCalendarStore((state) => state.viewCalendarItemAction);
+  const clearError = useCalendarStore((state) => state.clearError);
 
   useEffect(() => {
     // Initialize data on mount using new Angular-style actions
@@ -79,20 +77,23 @@ export default function CalendarScreen() {
     }
   };
 
-  const handleItemPress = (item: CalendarItemResultData) => {
-    setSelectedItem(item);
-    viewCalendarItemAction(item); // Update store state to match Angular
-    setIsDetailsSheetOpen(true);
+  const handleItemPress = React.useCallback(
+    (item: CalendarItemResultData) => {
+      setSelectedItem(item);
+      viewCalendarItemAction(item); // Update store state to match Angular
+      setIsDetailsSheetOpen(true);
 
-    // Track analytics for item interaction
-    trackEvent('calendar_item_viewed', {
-      timestamp: new Date().toISOString(),
-      itemId: item.CalendarItemId,
-      itemTitle: item.Title,
-      itemType: item.TypeName,
-      tab: activeTab,
-    });
-  };
+      // Track analytics for item interaction
+      trackEvent('calendar_item_viewed', {
+        timestamp: new Date().toISOString(),
+        itemId: item.CalendarItemId,
+        itemTitle: item.Title,
+        itemType: item.TypeName,
+        tab: activeTab,
+      });
+    },
+    [activeTab, trackEvent, viewCalendarItemAction]
+  );
 
   const handleMonthChange = (startDate: string, endDate: string) => {
     loadCalendarItemsForDateRange(startDate, endDate);
@@ -105,7 +106,7 @@ export default function CalendarScreen() {
     });
   };
 
-  const getItemsForSelectedDate = () => {
+  const itemsForSelectedDate = React.useMemo(() => {
     if (!selectedDate) return [];
 
     return selectedMonthItems.filter((item) => {
@@ -115,7 +116,7 @@ export default function CalendarScreen() {
       // 3. single-day events still work (start === end collapses to an exact match)
       return isDateInRange(selectedDate, item.Start, item.End, item.IsAllDay);
     });
-  };
+  }, [selectedDate, selectedMonthItems]);
 
   const renderTabButton = (tab: TabType, label: string) => (
     <Button
@@ -136,9 +137,11 @@ export default function CalendarScreen() {
     </Button>
   );
 
-  const renderCalendarItem = ({ item }: { item: CalendarItemResultData }) => <CalendarCard item={item} onPress={() => handleItemPress(item)} />;
+  const renderCalendarItem = React.useCallback(({ item }: { item: CalendarItemResultData }) => <CalendarCard item={item} onPress={() => handleItemPress(item)} />, [handleItemPress]);
 
-  const renderCompactCalendarItem = ({ item }: { item: CalendarItemResultData }) => <CompactCalendarItem item={item} onPress={() => handleItemPress(item)} />;
+  const renderCompactCalendarItem = React.useCallback(({ item }: { item: CalendarItemResultData }) => <CompactCalendarItem item={item} onPress={() => handleItemPress(item)} />, [handleItemPress]);
+
+  const calendarItemKeyExtractor = React.useCallback((item: CalendarItemResultData) => item.CalendarItemId, []);
 
   const renderTodayTab = () => {
     if (isTodaysLoading) {
@@ -163,7 +166,7 @@ export default function CalendarScreen() {
       <FlatList
         data={todayCalendarItems}
         renderItem={renderCalendarItem}
-        keyExtractor={(item) => item.CalendarItemId}
+        keyExtractor={calendarItemKeyExtractor}
         className="flex-1"
         contentContainerStyle={{ padding: 16 }}
         showsVerticalScrollIndicator={true}
@@ -195,7 +198,7 @@ export default function CalendarScreen() {
       <FlatList
         data={upcomingCalendarItems}
         renderItem={renderCalendarItem}
-        keyExtractor={(item) => item.CalendarItemId}
+        keyExtractor={calendarItemKeyExtractor}
         className="flex-1"
         contentContainerStyle={{ padding: 16 }}
         showsVerticalScrollIndicator={true}
@@ -212,10 +215,10 @@ export default function CalendarScreen() {
           <View className="flex-1 border-t border-gray-200 dark:border-gray-800">
             {isLoading ? (
               <Loading text={t('calendar.loading.date')} />
-            ) : getItemsForSelectedDate().length === 0 ? (
+            ) : itemsForSelectedDate.length === 0 ? (
               <Text className="py-8 text-center text-gray-500 dark:text-gray-400">{t('calendar.selectedDate.empty')}</Text>
             ) : (
-              <FlatList data={getItemsForSelectedDate()} renderItem={renderCompactCalendarItem} keyExtractor={(item) => item.CalendarItemId} showsVerticalScrollIndicator={true} contentContainerStyle={{ padding: 8 }} />
+              <FlatList data={itemsForSelectedDate} renderItem={renderCompactCalendarItem} keyExtractor={calendarItemKeyExtractor} showsVerticalScrollIndicator={true} contentContainerStyle={{ padding: 8 }} />
             )}
           </View>
         ) : (

--- a/src/app/(app)/contacts.tsx
+++ b/src/app/(app)/contacts.tsx
@@ -15,11 +15,17 @@ import { Pressable as UIPressable } from '@/components/ui/pressable';
 import { RefreshControl } from '@/components/ui/refresh-control';
 import { View } from '@/components/ui/view';
 import { useAnalytics } from '@/hooks/use-analytics';
+import { type ContactResultData } from '@/models/v4/contacts/contactResultData';
 import { useContactsStore } from '@/stores/contacts/store';
 
 export default function Contacts() {
   const { t } = useTranslation();
-  const { contacts, searchQuery, setSearchQuery, selectContact, isLoading, fetchContacts } = useContactsStore();
+  const contacts = useContactsStore((state) => state.contacts);
+  const searchQuery = useContactsStore((state) => state.searchQuery);
+  const setSearchQuery = useContactsStore((state) => state.setSearchQuery);
+  const selectContact = useContactsStore((state) => state.selectContact);
+  const isLoading = useContactsStore((state) => state.isLoading);
+  const fetchContacts = useContactsStore((state) => state.fetchContacts);
   const { trackEvent } = useAnalytics();
   const [refreshing, setRefreshing] = React.useState(false);
 
@@ -41,6 +47,8 @@ export default function Contacts() {
     await fetchContacts();
     setRefreshing(false);
   }, [fetchContacts]);
+
+  const renderContactItem = React.useCallback(({ item }: { item: ContactResultData }) => <ContactCard contact={item} onPress={selectContact} />, [selectContact]);
 
   const filteredContacts = React.useMemo(() => {
     if (!searchQuery.trim()) return contacts;
@@ -86,7 +94,7 @@ export default function Contacts() {
             testID="contacts-list"
             data={filteredContacts}
             keyExtractor={(item) => item.ContactId}
-            renderItem={({ item }) => <ContactCard contact={item} onPress={selectContact} />}
+            renderItem={renderContactItem}
             showsVerticalScrollIndicator={false}
             contentContainerStyle={{ paddingBottom: 100 }}
             refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}

--- a/src/app/(app)/home/__tests__/calls.test.tsx
+++ b/src/app/(app)/home/__tests__/calls.test.tsx
@@ -167,6 +167,9 @@ const mockUseCoreStore = useCoreStore as jest.MockedFunction<typeof useCoreStore
 const mockUseSecurityStore = useSecurityStore as jest.MockedFunction<typeof useSecurityStore>;
 const mockUseAnalytics = useAnalytics as jest.MockedFunction<typeof useAnalytics>;
 
+const setCallsStoreMock = (state: unknown) =>
+  mockUseCallsStore.mockImplementation(((selector?: (s: unknown) => unknown) => (selector ? selector(state) : state)) as any);
+
 describe('Calls Screen', () => {
   const mockFetchCalls = jest.fn();
   const mockFetchCallPriorities = jest.fn();
@@ -179,7 +182,7 @@ describe('Calls Screen', () => {
       trackEvent: mockTrackEvent,
     });
 
-    mockUseCallsStore.mockReturnValue({
+    setCallsStoreMock({
       calls: [],
       isLoading: false,
       error: null,
@@ -211,7 +214,7 @@ describe('Calls Screen', () => {
   });
 
   it('renders loading state', () => {
-    mockUseCallsStore.mockReturnValue({
+    setCallsStoreMock({
       calls: [],
       isLoading: true,
       error: null,
@@ -228,7 +231,7 @@ describe('Calls Screen', () => {
   });
 
   it('renders error state', () => {
-    mockUseCallsStore.mockReturnValue({
+    setCallsStoreMock({
       calls: [],
       isLoading: false,
       error: 'Test error',
@@ -279,7 +282,7 @@ describe('Calls Screen', () => {
   });
 
   it('filters calls based on search query', () => {
-    mockUseCallsStore.mockReturnValue({
+    setCallsStoreMock({
       calls: [
         { CallId: '1', Name: 'Fire Call', Nature: 'Fire Emergency', Address: 'Main', Priority: 1 },
         { CallId: '2', Name: 'Medical Call', Nature: 'Medical Emergency', Address: 'Oak', Priority: 2 },
@@ -302,7 +305,7 @@ describe('Calls Screen', () => {
   });
 
   it("filters to only calls I'm on", () => {
-    mockUseCallsStore.mockReturnValue({
+    setCallsStoreMock({
       calls: [
         { CallId: '1', Name: 'Fire Call', Nature: 'Fire Emergency', Address: 'Main', Priority: 1 },
         { CallId: '2', Name: 'Medical Call', Nature: 'Medical Emergency', Address: 'Oak', Priority: 2 },

--- a/src/app/(app)/home/calls.tsx
+++ b/src/app/(app)/home/calls.tsx
@@ -24,7 +24,13 @@ import { useRolesStore } from '@/stores/roles/store';
 import { useSecurityStore } from '@/stores/security/store';
 
 export default function Calls() {
-  const { calls, isLoading, error, fetchCalls, fetchCallPriorities, callPriorities, callExtrasById } = useCallsStore();
+  const calls = useCallsStore((state) => state.calls);
+  const isLoading = useCallsStore((state) => state.isLoading);
+  const error = useCallsStore((state) => state.error);
+  const fetchCalls = useCallsStore((state) => state.fetchCalls);
+  const fetchCallPriorities = useCallsStore((state) => state.fetchCallPriorities);
+  const callPriorities = useCallsStore((state) => state.callPriorities);
+  const callExtrasById = useCallsStore((state) => state.callExtrasById);
   const { canUserCreateCalls } = useSecurityStore();
   const { trackEvent } = useAnalytics();
   const { t } = useTranslation();
@@ -61,6 +67,12 @@ export default function Calls() {
 
   const assignmentContext = useMemo(() => buildCallAssignmentContext(currentUser, roles, activeUnitId), [activeUnitId, currentUser, roles]);
 
+  const priorityById = useMemo(() => {
+    const map = new Map<number, (typeof callPriorities)[number]>();
+    callPriorities.forEach((priority) => map.set(priority.Id, priority));
+    return map;
+  }, [callPriorities]);
+
   const filteredCalls = useMemo(() => {
     const normalizedSearchQuery = searchQuery.toLowerCase();
 
@@ -79,6 +91,17 @@ export default function Calls() {
     });
   }, [assignmentContext, callExtrasById, calls, onlyCallsImOn, searchQuery]);
 
+  const keyExtractor = useCallback((item: CallResultData) => item.CallId, []);
+
+  const renderCallItem = useCallback(
+    ({ item }: { item: CallResultData }) => (
+      <Pressable onPress={() => router.push(`/call/${item.CallId}`)}>
+        <CallCard call={item} priority={priorityById.get(item.Priority)} callExtraData={callExtrasById[item.CallId]} />
+      </Pressable>
+    ),
+    [priorityById, callExtrasById]
+  );
+
   const renderContent = () => {
     if (isLoading) {
       return <Loading text={t('calls.loading')} />;
@@ -91,12 +114,8 @@ export default function Calls() {
     return (
       <FlatList<CallResultData>
         data={filteredCalls}
-        renderItem={({ item }: { item: CallResultData }) => (
-          <Pressable onPress={() => router.push(`/call/${item.CallId}`)}>
-            <CallCard call={item} priority={callPriorities.find((p: { Id: number }) => p.Id === item.Priority)} callExtraData={callExtrasById[item.CallId]} />
-          </Pressable>
-        )}
-        keyExtractor={(item: CallResultData) => item.CallId}
+        renderItem={renderCallItem}
+        keyExtractor={keyExtractor}
         refreshControl={<RefreshControl refreshing={false} onRefresh={handleRefresh} />}
         ListEmptyComponent={<ZeroState heading={t('calls.no_calls')} description={t('calls.no_calls_description')} icon={RefreshCcwDotIcon} />}
         contentContainerStyle={{ paddingBottom: 20 }}

--- a/src/app/(app)/home/calls.tsx
+++ b/src/app/(app)/home/calls.tsx
@@ -96,7 +96,7 @@ export default function Calls() {
   const renderCallItem = useCallback(
     ({ item }: { item: CallResultData }) => (
       <Pressable onPress={() => router.push(`/call/${item.CallId}`)}>
-        <CallCard call={item} priority={priorityById.get(item.Priority)} callExtraData={callExtrasById[item.CallId]} />
+        <CallCard call={item} priority={priorityById.get(item.Priority)} callExtraData={callExtrasById[item.CallId] ?? null} />
       </Pressable>
     ),
     [priorityById, callExtrasById]

--- a/src/app/(app)/home/index.tsx
+++ b/src/app/(app)/home/index.tsx
@@ -1,5 +1,5 @@
 import { useFocusEffect } from '@react-navigation/native';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView } from 'react-native';
 
@@ -26,11 +26,12 @@ import { useHomeStore } from '@/stores/home/home-store';
 
 export default function HomeDashboard() {
   const { t } = useTranslation();
-  const { refreshAll } = useHomeStore();
+  const refreshAll = useHomeStore((state) => state.refreshAll);
   const getStatusesAndStaffing = useCoreStore((state) => state.getStatusesAndStaffing);
   const { trackEvent } = useAnalytics();
   const activeCall = useActiveCallStore((state) => state.activeCall);
-  const overdueCount = useCheckInStore((state) => state.timerStatuses.filter((s) => s.Status === 'Overdue').length);
+  const timerStatuses = useCheckInStore((state) => state.timerStatuses);
+  const overdueCount = useMemo(() => timerStatuses.filter((s) => s.Status === 'Overdue').length, [timerStatuses]);
   const calls = useCallsStore((state) => state.calls);
   const fetchCalls = useCallsStore((state) => state.fetchCalls);
   const fetchGlobalOverdueCount = useCheckInStore((state) => state.fetchGlobalOverdueCount);

--- a/src/app/(app)/home/personnel.tsx
+++ b/src/app/(app)/home/personnel.tsx
@@ -25,19 +25,11 @@ import { usePersonnelStore } from '@/stores/personnel/store';
 
 type PersonnelListItem = PersonnelInfoResultData & { syntheticId: string };
 
-const syntheticIds = new WeakMap<PersonnelInfoResultData, string>();
-let nextSyntheticId = 0;
-
 const normalizePersonnel = (personnel: PersonnelInfoResultData[]): PersonnelListItem[] =>
-  personnel.map((person) => {
-    let syntheticId = syntheticIds.get(person);
-    if (!syntheticId) {
-      syntheticId = `personnel-${++nextSyntheticId}`;
-      syntheticIds.set(person, syntheticId);
-    }
-
-    return { ...person, syntheticId };
-  });
+  personnel.map((person) => ({
+    ...person,
+    syntheticId: `personnel-${person.UserId}`,
+  }));
 
 export default function Personnel() {
   const { t } = useTranslation();

--- a/src/app/(app)/home/personnel.tsx
+++ b/src/app/(app)/home/personnel.tsx
@@ -20,11 +20,19 @@ import { InputField, InputIcon, InputSlot } from '@/components/ui/input';
 import { RefreshControl } from '@/components/ui/refresh-control';
 import { Text } from '@/components/ui/text';
 import { useAnalytics } from '@/hooks/use-analytics';
+import { type PersonnelInfoResultData } from '@/models/v4/personnel/personnelInfoResultData';
 import { usePersonnelStore } from '@/stores/personnel/store';
 
 export default function Personnel() {
   const { t } = useTranslation();
-  const { personnel, searchQuery, setSearchQuery, selectPersonnel, isLoading, fetchPersonnel, selectedFilters, openFilterSheet } = usePersonnelStore();
+  const personnel = usePersonnelStore((state) => state.personnel);
+  const searchQuery = usePersonnelStore((state) => state.searchQuery);
+  const setSearchQuery = usePersonnelStore((state) => state.setSearchQuery);
+  const selectPersonnel = usePersonnelStore((state) => state.selectPersonnel);
+  const isLoading = usePersonnelStore((state) => state.isLoading);
+  const fetchPersonnel = usePersonnelStore((state) => state.fetchPersonnel);
+  const selectedFilters = usePersonnelStore((state) => state.selectedFilters);
+  const openFilterSheet = usePersonnelStore((state) => state.openFilterSheet);
   const { trackEvent } = useAnalytics();
   const [refreshing, setRefreshing] = React.useState(false);
 
@@ -59,6 +67,10 @@ export default function Personnel() {
     );
   }, [personnel, searchQuery]);
 
+  const keyExtractor = React.useCallback((item: PersonnelInfoResultData, index: number) => item.UserId || item.EmailAddress || item.IdentificationNumber || `personnel-${index}`, []);
+
+  const renderPersonnelItem = React.useCallback(({ item }: { item: PersonnelInfoResultData }) => <PersonnelCard personnel={item} onPress={selectPersonnel} />, [selectPersonnel]);
+
   return (
     <>
       <View className="flex-1 bg-gray-50 dark:bg-gray-900">
@@ -79,11 +91,11 @@ export default function Personnel() {
             <Button onPress={openFilterSheet} className="h-10 rounded-lg bg-white dark:bg-gray-800" variant="outline" testID="filter-button">
               <HStack className="items-center" space="xs">
                 <Filter size={20} className="text-gray-600 dark:text-gray-400" />
-                {selectedFilters.length > 0 && (
+                {selectedFilters.length > 0 ? (
                   <Badge size="sm" variant="solid" className="bg-blue-500">
                     <Text className="text-xs text-white">{selectedFilters.length}</Text>
                   </Badge>
-                )}
+                ) : null}
               </HStack>
             </Button>
           </HStack>
@@ -93,8 +105,8 @@ export default function Personnel() {
           ) : filteredPersonnel.length > 0 ? (
             <FlashList
               data={filteredPersonnel}
-              keyExtractor={(item, index) => item.UserId || `personnel-${index}`}
-              renderItem={({ item }) => <PersonnelCard personnel={item} onPress={selectPersonnel} />}
+              keyExtractor={keyExtractor}
+              renderItem={renderPersonnelItem}
               showsVerticalScrollIndicator={false}
               contentContainerStyle={{ paddingBottom: 100 }}
               refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}

--- a/src/app/(app)/home/personnel.tsx
+++ b/src/app/(app)/home/personnel.tsx
@@ -23,6 +23,22 @@ import { useAnalytics } from '@/hooks/use-analytics';
 import { type PersonnelInfoResultData } from '@/models/v4/personnel/personnelInfoResultData';
 import { usePersonnelStore } from '@/stores/personnel/store';
 
+type PersonnelListItem = PersonnelInfoResultData & { syntheticId: string };
+
+const syntheticIds = new WeakMap<PersonnelInfoResultData, string>();
+let nextSyntheticId = 0;
+
+const normalizePersonnel = (personnel: PersonnelInfoResultData[]): PersonnelListItem[] =>
+  personnel.map((person) => {
+    let syntheticId = syntheticIds.get(person);
+    if (!syntheticId) {
+      syntheticId = `personnel-${++nextSyntheticId}`;
+      syntheticIds.set(person, syntheticId);
+    }
+
+    return { ...person, syntheticId };
+  });
+
 export default function Personnel() {
   const { t } = useTranslation();
   const personnel = usePersonnelStore((state) => state.personnel);
@@ -49,12 +65,14 @@ export default function Personnel() {
     setRefreshing(false);
   }, [fetchPersonnel]);
 
+  const normalizedPersonnel = React.useMemo(() => (Array.isArray(personnel) ? normalizePersonnel(personnel) : []), [personnel]);
+
   const filteredPersonnel = React.useMemo(() => {
     if (!personnel || !Array.isArray(personnel)) return [];
-    if (!searchQuery.trim()) return personnel;
+    if (!searchQuery.trim()) return normalizedPersonnel;
 
     const query = searchQuery.toLowerCase();
-    return personnel.filter(
+    return normalizedPersonnel.filter(
       (person) =>
         person.FirstName?.toLowerCase().includes(query) ||
         person.LastName?.toLowerCase().includes(query) ||
@@ -65,11 +83,11 @@ export default function Personnel() {
         person.IdentificationNumber?.toLowerCase().includes(query) ||
         person.Roles?.some((role) => role.toLowerCase().includes(query))
     );
-  }, [personnel, searchQuery]);
+  }, [normalizedPersonnel, personnel, searchQuery]);
 
-  const keyExtractor = React.useCallback((item: PersonnelInfoResultData, index: number) => item.UserId || item.EmailAddress || item.IdentificationNumber || `personnel-${index}`, []);
+  const keyExtractor = React.useCallback((item: PersonnelListItem) => item.syntheticId, []);
 
-  const renderPersonnelItem = React.useCallback(({ item }: { item: PersonnelInfoResultData }) => <PersonnelCard personnel={item} onPress={selectPersonnel} />, [selectPersonnel]);
+  const renderPersonnelItem = React.useCallback(({ item }: { item: PersonnelListItem }) => <PersonnelCard personnel={item} onPress={selectPersonnel} />, [selectPersonnel]);
 
   return (
     <>

--- a/src/app/(app)/home/units.tsx
+++ b/src/app/(app)/home/units.tsx
@@ -21,11 +21,23 @@ import { UnitCard } from '@/components/units/unit-card';
 import { UnitDetailsSheet } from '@/components/units/unit-details-sheet';
 import { UnitsFilterSheet } from '@/components/units/units-filter-sheet';
 import { useAnalytics } from '@/hooks/use-analytics';
+import { type UnitInfoResultData } from '@/models/v4/units/unitInfoResultData';
+import { type UnitResultData } from '@/models/v4/units/unitResultData';
 import { useUnitsStore } from '@/stores/units/store';
+
+type UnitListItem = UnitResultData | UnitInfoResultData;
 
 export default function Units() {
   const { t } = useTranslation();
-  const { units, unitTypeStatuses, searchQuery, setSearchQuery, selectUnit, isLoading, fetchUnits, selectedFilters, openFilterSheet } = useUnitsStore();
+  const units = useUnitsStore((state) => state.units);
+  const unitTypeStatuses = useUnitsStore((state) => state.unitTypeStatuses);
+  const searchQuery = useUnitsStore((state) => state.searchQuery);
+  const setSearchQuery = useUnitsStore((state) => state.setSearchQuery);
+  const selectUnit = useUnitsStore((state) => state.selectUnit);
+  const isLoading = useUnitsStore((state) => state.isLoading);
+  const fetchUnits = useUnitsStore((state) => state.fetchUnits);
+  const selectedFilters = useUnitsStore((state) => state.selectedFilters);
+  const openFilterSheet = useUnitsStore((state) => state.openFilterSheet);
   const { trackEvent } = useAnalytics();
   const [refreshing, setRefreshing] = React.useState(false);
 
@@ -48,7 +60,9 @@ export default function Units() {
     setRefreshing(false);
   }, [fetchUnits]);
 
-  const renderUnitItem = useCallback(({ item }: { item: any }) => <UnitCard unit={item} unitTypeStatuses={unitTypeStatuses} onPress={selectUnit} />, [unitTypeStatuses, selectUnit]);
+  const keyExtractor = useCallback((item: UnitListItem, index: number) => item.UnitId || item.Name || `unit-${index}`, []);
+
+  const renderUnitItem = useCallback(({ item }: { item: UnitListItem }) => <UnitCard unit={item} unitTypeStatuses={unitTypeStatuses} onPress={selectUnit} />, [unitTypeStatuses, selectUnit]);
 
   const filteredUnits = React.useMemo(() => {
     if (!searchQuery.trim()) return units;
@@ -84,11 +98,11 @@ export default function Units() {
             <Button onPress={openFilterSheet} className="h-10 rounded-lg bg-white dark:bg-gray-800" variant="outline" testID="filter-button">
               <HStack className="items-center" space="xs">
                 <Filter size={20} className="text-gray-600 dark:text-gray-400" />
-                {selectedFilters.length > 0 && (
+                {selectedFilters.length > 0 ? (
                   <Badge size="sm" variant="solid" className="bg-blue-500">
                     <Text className="text-xs text-white">{selectedFilters.length}</Text>
                   </Badge>
-                )}
+                ) : null}
               </HStack>
             </Button>
           </HStack>
@@ -98,7 +112,7 @@ export default function Units() {
           ) : filteredUnits.length > 0 ? (
             <FlashList
               data={filteredUnits}
-              keyExtractor={(item, index) => item.UnitId || `unit-${index}`}
+              keyExtractor={keyExtractor}
               renderItem={renderUnitItem}
               showsVerticalScrollIndicator={false}
               contentContainerStyle={{ paddingBottom: 100 }}

--- a/src/app/(app)/messages.tsx
+++ b/src/app/(app)/messages.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { router, Stack } from 'expo-router';
 import { ChevronDown, Mail, MailOpen, MessageSquarePlus, MoreVertical, Search, Trash2, X } from 'lucide-react-native';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert } from 'react-native';
 
@@ -36,30 +36,29 @@ export default function MessagesScreen() {
   const { canUserCreateMessages } = useSecurityStore();
   const { trackEvent } = useAnalytics();
 
-  const {
-    isLoading,
-    error,
-    searchQuery,
-    currentFilter,
-    selectedForDeletion,
-    isDetailsOpen,
-    isComposeOpen,
-    isDeleting,
-    setSearchQuery,
-    setCurrentFilter,
-    selectMessage,
-    fetchInboxMessages,
-    fetchSentMessages,
-    getFilteredMessages,
-    hasSelectedMessages,
-    clearSelection,
-    selectAllVisibleMessages,
-    deleteMessages,
-    openCompose,
-    toggleMessageSelection,
-  } = useMessagesStore();
+  const isLoading = useMessagesStore((state) => state.isLoading);
+  const error = useMessagesStore((state) => state.error);
+  const searchQuery = useMessagesStore((state) => state.searchQuery);
+  const currentFilter = useMessagesStore((state) => state.currentFilter);
+  const selectedForDeletion = useMessagesStore((state) => state.selectedForDeletion);
+  const isDeleting = useMessagesStore((state) => state.isDeleting);
+  const inboxMessages = useMessagesStore((state) => state.inboxMessages);
+  const sentMessages = useMessagesStore((state) => state.sentMessages);
+  const setSearchQuery = useMessagesStore((state) => state.setSearchQuery);
+  const setCurrentFilter = useMessagesStore((state) => state.setCurrentFilter);
+  const selectMessage = useMessagesStore((state) => state.selectMessage);
+  const fetchInboxMessages = useMessagesStore((state) => state.fetchInboxMessages);
+  const fetchSentMessages = useMessagesStore((state) => state.fetchSentMessages);
+  const hasSelectedMessages = useMessagesStore((state) => state.hasSelectedMessages);
+  const clearSelection = useMessagesStore((state) => state.clearSelection);
+  const selectAllVisibleMessages = useMessagesStore((state) => state.selectAllVisibleMessages);
+  const deleteMessages = useMessagesStore((state) => state.deleteMessages);
+  const openCompose = useMessagesStore((state) => state.openCompose);
+  const toggleMessageSelection = useMessagesStore((state) => state.toggleMessageSelection);
 
-  const filteredMessages = getFilteredMessages();
+  // Deps drive recomputation; getState() read is intentional so the memo tracks store arrays.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const filteredMessages = useMemo(() => useMessagesStore.getState().getFilteredMessages(), [inboxMessages, sentMessages, searchQuery, currentFilter]);
 
   // Fetch messages when screen comes into focus
   useFocusEffect(
@@ -83,34 +82,40 @@ export default function MessagesScreen() {
     }, [fetchInboxMessages, fetchSentMessages, currentFilter, trackEvent, filteredMessages.length])
   );
 
-  const handleMessagePress = (message: MessageResultData) => {
-    if (isSelectionMode) {
-      toggleMessageSelection(message.MessageId);
-      trackEvent('message_selection_toggled', {
-        timestamp: new Date().toISOString(),
-        messageId: message.MessageId,
-        isSelected: !selectedForDeletion.has(message.MessageId),
-      });
-    } else {
-      selectMessage(message.MessageId);
-      trackEvent('message_selected', {
-        timestamp: new Date().toISOString(),
-        messageId: message.MessageId,
-        messageType: message.Type.toString(),
-      });
-    }
-  };
+  const handleMessagePress = useCallback(
+    (message: MessageResultData) => {
+      if (isSelectionMode) {
+        toggleMessageSelection(message.MessageId);
+        trackEvent('message_selection_toggled', {
+          timestamp: new Date().toISOString(),
+          messageId: message.MessageId,
+          isSelected: !selectedForDeletion.has(message.MessageId),
+        });
+      } else {
+        selectMessage(message.MessageId);
+        trackEvent('message_selected', {
+          timestamp: new Date().toISOString(),
+          messageId: message.MessageId,
+          messageType: message.Type.toString(),
+        });
+      }
+    },
+    [isSelectionMode, selectedForDeletion, selectMessage, toggleMessageSelection, trackEvent]
+  );
 
-  const handleLongPress = (message: MessageResultData) => {
-    if (!isSelectionMode) {
-      setIsSelectionMode(true);
-      toggleMessageSelection(message.MessageId);
-      trackEvent('message_selection_mode_entered', {
-        timestamp: new Date().toISOString(),
-        messageId: message.MessageId,
-      });
-    }
-  };
+  const handleLongPress = useCallback(
+    (message: MessageResultData) => {
+      if (!isSelectionMode) {
+        setIsSelectionMode(true);
+        toggleMessageSelection(message.MessageId);
+        trackEvent('message_selection_mode_entered', {
+          timestamp: new Date().toISOString(),
+          messageId: message.MessageId,
+        });
+      }
+    },
+    [isSelectionMode, toggleMessageSelection, trackEvent]
+  );
 
   const handleDeleteSelected = () => {
     const selectedMessages = Array.from(selectedForDeletion);
@@ -193,9 +198,14 @@ export default function MessagesScreen() {
     }
   };
 
-  const renderMessage = ({ item }: { item: MessageResultData }) => (
-    <MessageCard message={item} onPress={() => handleMessagePress(item)} onLongPress={() => handleLongPress(item)} isSelected={selectedForDeletion.has(item.MessageId)} showCheckbox={isSelectionMode} />
+  const renderMessage = useCallback(
+    ({ item }: { item: MessageResultData }) => (
+      <MessageCard message={item} onPress={() => handleMessagePress(item)} onLongPress={() => handleLongPress(item)} isSelected={selectedForDeletion.has(item.MessageId)} showCheckbox={isSelectionMode} />
+    ),
+    [handleMessagePress, handleLongPress, isSelectionMode, selectedForDeletion]
   );
+
+  const keyExtractor = useCallback((item: MessageResultData, index: number) => item.MessageId || `message-${index}`, []);
 
   if (isLoading && filteredMessages.length === 0) {
     return <Loading />;
@@ -293,7 +303,7 @@ export default function MessagesScreen() {
           <FlatList
             data={filteredMessages}
             renderItem={renderMessage}
-            keyExtractor={(item, index) => item.MessageId || `message-${index}`}
+            keyExtractor={keyExtractor}
             className="flex-1"
             contentContainerStyle={{ paddingBottom: 16 }}
             showsVerticalScrollIndicator={false}
@@ -317,7 +327,7 @@ export default function MessagesScreen() {
           />
         )}
 
-        {isLoading && filteredMessages.length === 0 && <Loading />}
+        {isLoading && filteredMessages.length === 0 ? <Loading /> : null}
 
         {/* Filter Action Sheet */}
         <Actionsheet isOpen={isFilterMenuOpen} onClose={() => setIsFilterMenuOpen(false)}>
@@ -394,11 +404,11 @@ export default function MessagesScreen() {
         <ComposeMessageSheet />
 
         {/* FAB button for composing new message */}
-        {!isSelectionMode && canUserCreateMessages && (
+        {!isSelectionMode && canUserCreateMessages ? (
           <Fab placement="bottom right" size="lg" onPress={() => handleOpenCompose('fab')} testID="messages-compose-fab">
             <FabIcon as={MessageSquarePlus} size="lg" />
           </Fab>
-        )}
+        ) : null}
       </View>
     </>
   );

--- a/src/app/(app)/protocols.tsx
+++ b/src/app/(app)/protocols.tsx
@@ -14,11 +14,17 @@ import { Input, InputField, InputIcon, InputSlot } from '@/components/ui/input';
 import { RefreshControl } from '@/components/ui/refresh-control';
 import { View } from '@/components/ui/view';
 import { useAnalytics } from '@/hooks/use-analytics';
+import { type CallProtocolsResultData } from '@/models/v4/callProtocols/callProtocolsResultData';
 import { useProtocolsStore } from '@/stores/protocols/store';
 
 export default function Protocols() {
   const { t } = useTranslation();
-  const { protocols, searchQuery, setSearchQuery, selectProtocol, isLoading, fetchProtocols } = useProtocolsStore();
+  const protocols = useProtocolsStore((state) => state.protocols);
+  const searchQuery = useProtocolsStore((state) => state.searchQuery);
+  const setSearchQuery = useProtocolsStore((state) => state.setSearchQuery);
+  const selectProtocol = useProtocolsStore((state) => state.selectProtocol);
+  const isLoading = useProtocolsStore((state) => state.isLoading);
+  const fetchProtocols = useProtocolsStore((state) => state.fetchProtocols);
   const { trackEvent } = useAnalytics();
   const [refreshing, setRefreshing] = React.useState(false);
 
@@ -40,6 +46,10 @@ export default function Protocols() {
     await fetchProtocols();
     setRefreshing(false);
   }, [fetchProtocols]);
+
+  const keyExtractor = React.useCallback((item: CallProtocolsResultData, index: number) => item.ProtocolId || `protocol-${index}`, []);
+
+  const renderProtocolItem = React.useCallback(({ item }: { item: CallProtocolsResultData }) => <ProtocolCard protocol={item} onPress={selectProtocol} />, [selectProtocol]);
 
   const filteredProtocols = React.useMemo(() => {
     if (!searchQuery.trim()) return protocols;
@@ -77,8 +87,8 @@ export default function Protocols() {
           <FlashList
             testID="protocols-list"
             data={filteredProtocols}
-            keyExtractor={(item, index) => item.ProtocolId || `protocol-${index}`}
-            renderItem={({ item }) => <ProtocolCard protocol={item} onPress={selectProtocol} />}
+            keyExtractor={keyExtractor}
+            renderItem={renderProtocolItem}
             showsVerticalScrollIndicator={false}
             contentContainerStyle={{ paddingBottom: 100 }}
             refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}

--- a/src/app/(app)/shifts.tsx
+++ b/src/app/(app)/shifts.tsx
@@ -28,28 +28,22 @@ import { type ShiftViewMode, useShiftsStore } from '@/stores/shifts/store';
 const ShiftsScreen: React.FC = () => {
   const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
-  const {
-    // Data
-    shifts,
-    todaysShiftDays,
-    // UI State
-    currentView,
-    searchQuery,
-    isShiftDetailsOpen,
-    isShiftDayDetailsOpen,
-    // Loading states
-    isLoading,
-    isTodaysLoading,
-    // Actions
-    setCurrentView,
-    setSearchQuery,
-    fetchAllShifts,
-    fetchTodaysShifts,
-    closeShiftDetails,
-    closeShiftDayDetails,
-    selectShift,
-    selectShiftDay,
-  } = useShiftsStore();
+  const shifts = useShiftsStore((state) => state.shifts);
+  const todaysShiftDays = useShiftsStore((state) => state.todaysShiftDays);
+  const currentView = useShiftsStore((state) => state.currentView);
+  const searchQuery = useShiftsStore((state) => state.searchQuery);
+  const isShiftDetailsOpen = useShiftsStore((state) => state.isShiftDetailsOpen);
+  const isShiftDayDetailsOpen = useShiftsStore((state) => state.isShiftDayDetailsOpen);
+  const isLoading = useShiftsStore((state) => state.isLoading);
+  const isTodaysLoading = useShiftsStore((state) => state.isTodaysLoading);
+  const setCurrentView = useShiftsStore((state) => state.setCurrentView);
+  const setSearchQuery = useShiftsStore((state) => state.setSearchQuery);
+  const fetchAllShifts = useShiftsStore((state) => state.fetchAllShifts);
+  const fetchTodaysShifts = useShiftsStore((state) => state.fetchTodaysShifts);
+  const closeShiftDetails = useShiftsStore((state) => state.closeShiftDetails);
+  const closeShiftDayDetails = useShiftsStore((state) => state.closeShiftDayDetails);
+  const selectShift = useShiftsStore((state) => state.selectShift);
+  const selectShiftDay = useShiftsStore((state) => state.selectShiftDay);
 
   const filteredShifts = useMemo(() => {
     if (!searchQuery.trim()) return shifts;

--- a/src/app/login/sso.tsx
+++ b/src/app/login/sso.tsx
@@ -9,7 +9,7 @@ import { Button, ButtonText } from '@/components/ui/button';
 import { Modal, ModalBackdrop, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@/components/ui/modal';
 import { Text } from '@/components/ui/text';
 import { useAnalytics } from '@/hooks/use-analytics';
-import { useOidcLogin } from '@/hooks/use-oidc-login';
+import { isValidSsoUrl, useOidcLogin } from '@/hooks/use-oidc-login';
 import { useSamlLogin } from '@/hooks/use-saml-login';
 import { useAuth } from '@/lib/auth';
 import { logger } from '@/lib/logging';
@@ -99,6 +99,26 @@ export default function SsoLogin() {
     setSsoPhase('department');
   }, []);
 
+  const handleOidcPress = useCallback(() => {
+    const authorityUrl = ssoConfig?.authority ?? '';
+    if (!isValidSsoUrl(authorityUrl)) {
+      logger.error({ message: 'SSO: refusing OIDC login with invalid or insecure authority URL' });
+      setIsErrorModalVisible(true);
+      return;
+    }
+    void oidc.promptAsync();
+  }, [oidc, ssoConfig]);
+
+  const handleSamlPress = useCallback(() => {
+    const samlUrl = ssoConfig?.metadataUrl ?? ssoConfig?.authority ?? '';
+    if (!isValidSsoUrl(samlUrl)) {
+      logger.error({ message: 'SSO: refusing SAML login with invalid or insecure IdP URL' });
+      setIsErrorModalVisible(true);
+      return;
+    }
+    void saml.startSamlLogin();
+  }, [saml, ssoConfig]);
+
   const ssoEnabled = ssoConfig?.ssoEnabled ?? false;
 
   return (
@@ -117,8 +137,8 @@ export default function SsoLogin() {
         <SsoLoginButtons
           departmentCode={username}
           ssoConfig={ssoConfig}
-          onOidcPress={() => oidc.promptAsync()}
-          onSamlPress={() => saml.startSamlLogin()}
+          onOidcPress={handleOidcPress}
+          onSamlPress={handleSamlPress}
           onChangeDepartment={handleChangeDepartment}
           oidcRequestReady={!!oidc.request}
           isLoading={status === 'loading'}

--- a/src/components/calls/call-card.tsx
+++ b/src/components/calls/call-card.tsx
@@ -131,7 +131,7 @@ const DispatchTicker: React.FC<DispatchTickerProps> = ({ dispatches }) => {
   );
 };
 
-export const CallCard: React.FC<CallCardProps> = ({ call, priority, callExtraData }) => {
+export const CallCard: React.FC<CallCardProps> = React.memo(function CallCard({ call, priority, callExtraData }) {
   const { t } = useTranslation();
   const currentUser = useHomeStore((state) => state.currentUser);
   const roles = useRolesStore((state) => state.roles);
@@ -255,7 +255,7 @@ export const CallCard: React.FC<CallCardProps> = ({ call, priority, callExtraDat
       ) : null}
     </Box>
   );
-};
+});
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/calls/call-images-modal.tsx
+++ b/src/components/calls/call-images-modal.tsx
@@ -54,7 +54,8 @@ const CallImagesModal: React.FC<CallImagesModalProps> = ({ isOpen, onClose, call
   const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
   const { colorScheme } = useColorScheme();
-  const { latitude, longitude } = useLocationStore();
+  const latitude = useLocationStore((state) => state.latitude);
+  const longitude = useLocationStore((state) => state.longitude);
   const { showToast } = useToastStore();
 
   // Create dynamic styles based on color scheme

--- a/src/components/calls/call-images-modal.tsx
+++ b/src/components/calls/call-images-modal.tsx
@@ -142,9 +142,10 @@ const CallImagesModal: React.FC<CallImagesModalProps> = ({ isOpen, onClose, call
 
   const handleImageSelect = async () => {
     try {
-      // On Web, permissions are handled by the browser, so we skip the permission check
-      // On iOS/Android, we need to request permissions first
-      if (Platform.OS !== 'web') {
+      // Android uses the system photo picker, which grants access only to the
+      // selected item and does not require broad media-library permission.
+      // iOS still uses its media-library permission flow.
+      if (Platform.OS === 'ios') {
         const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
         if (permissionResult.granted === false) {
           // Check if user can be asked again or needs to go to settings
@@ -159,6 +160,7 @@ const CallImagesModal: React.FC<CallImagesModalProps> = ({ isOpen, onClose, call
 
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        legacy: false,
         // Disable allowsEditing on all platforms - it can cause issues with high-res images
         // On iOS: UIImagePickerController bugs cause crashes
         // On Android: Can cause silent failures with certain device/image configurations

--- a/src/components/check-in/check-in-bottom-sheet.tsx
+++ b/src/components/check-in/check-in-bottom-sheet.tsx
@@ -106,11 +106,7 @@ export const CheckInBottomSheet: React.FC<CheckInBottomSheetProps> = ({ isOpen, 
           </Input>
         </VStack>
 
-        {latitude != null && longitude != null ? (
-          <Text className="text-xs text-gray-500">
-            GPS: {latitude.toFixed(5)}, {longitude.toFixed(5)}
-          </Text>
-        ) : null}
+        {latitude != null && longitude != null ? <Text className="text-xs text-gray-500">{t('check_in.gps_coordinates', { latitude: latitude.toFixed(5), longitude: longitude.toFixed(5) })}</Text> : null}
 
         <Button size="lg" onPress={handleSubmit} isDisabled={isLoading} testID="confirm-check-in-button">
           <ButtonText>{t('check_in.confirm_check_in')}</ButtonText>

--- a/src/components/check-in/check-in-bottom-sheet.tsx
+++ b/src/components/check-in/check-in-bottom-sheet.tsx
@@ -48,7 +48,8 @@ export const CheckInBottomSheet: React.FC<CheckInBottomSheetProps> = ({ isOpen, 
   const { colorScheme } = useColorScheme();
   const [selectedType, setSelectedType] = useState(defaultCheckInType);
   const [note, setNote] = useState('');
-  const location = useLocationStore();
+  const latitude = useLocationStore((state) => state.latitude);
+  const longitude = useLocationStore((state) => state.longitude);
   const resolvedTargetName = targetName?.trim() ?? '';
   const isCardDrivenCheckIn = defaultUnitId !== undefined || resolvedTargetName.length > 0;
   const shouldShowTargetName = shouldUseNamedCheckInTarget(defaultCheckInType) && resolvedTargetName.length > 0;
@@ -69,13 +70,13 @@ export const CheckInBottomSheet: React.FC<CheckInBottomSheetProps> = ({ isOpen, 
       CallId: callId,
       CheckInType: selectedType,
       UnitId: defaultUnitId,
-      Latitude: location.latitude?.toString(),
-      Longitude: location.longitude?.toString(),
+      Latitude: latitude?.toString(),
+      Longitude: longitude?.toString(),
       Note: note.trim() || undefined,
     });
     setNote('');
     onClose();
-  }, [callId, selectedType, defaultUnitId, location, note, onSubmit, onClose]);
+  }, [callId, selectedType, defaultUnitId, latitude, longitude, note, onSubmit, onClose]);
 
   const activeBg = colorScheme === 'dark' ? 'bg-primary-700' : 'bg-primary-100';
   const inactiveBg = colorScheme === 'dark' ? 'bg-neutral-800' : 'bg-gray-100';
@@ -105,9 +106,9 @@ export const CheckInBottomSheet: React.FC<CheckInBottomSheetProps> = ({ isOpen, 
           </Input>
         </VStack>
 
-        {location.latitude != null && location.longitude != null ? (
+        {latitude != null && longitude != null ? (
           <Text className="text-xs text-gray-500">
-            GPS: {location.latitude.toFixed(5)}, {location.longitude.toFixed(5)}
+            GPS: {latitude.toFixed(5)}, {longitude.toFixed(5)}
           </Text>
         ) : null}
 

--- a/src/components/maps/__tests__/full-screen-location-picker.test.tsx
+++ b/src/components/maps/__tests__/full-screen-location-picker.test.tsx
@@ -38,7 +38,7 @@ const mockLocationStore = {
 };
 
 jest.mock('@/stores/app/location-store', () => ({
-  useLocationStore: () => mockLocationStore,
+  useLocationStore: (selector?: (state: typeof mockLocationStore) => unknown) => (selector ? selector(mockLocationStore) : mockLocationStore),
 }));
 
 // Mock location service

--- a/src/components/maps/__tests__/map-pins-pii.test.tsx
+++ b/src/components/maps/__tests__/map-pins-pii.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react-native';
 import React from 'react';
 
 import { type MapMakerInfoData } from '@/models/v4/mapping/getMapDataAndMarkersData';
-import { useSecurityStore } from '@/stores/security/store';
+import { securityStore } from '@/stores/security/store';
 
 import MapPins from '../map-pins';
 
@@ -12,8 +12,14 @@ jest.mock('@rnmapbox/maps', () => ({
 }));
 
 // Mock the security store
-jest.mock('@/stores/security/store');
-const mockUseSecurityStore = useSecurityStore as jest.MockedFunction<typeof useSecurityStore>;
+jest.mock('@/stores/security/store', () => ({
+  securityStore: jest.fn(),
+}));
+const mockSecurityStore = securityStore as jest.MockedFunction<typeof securityStore>;
+
+const mockCanUserViewPII = (canView: boolean) => {
+  mockSecurityStore.mockImplementation((selector: any) => selector({ rights: { CanViewPII: canView } }));
+};
 
 // Mock PinMarker component
 jest.mock('../pin-marker', () => {
@@ -75,9 +81,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should show all pins when user can view PII', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: true,
-    } as any);
+    mockCanUserViewPII(true);
 
     render(
       <MapPins
@@ -92,9 +96,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should hide personnel pins when user cannot view PII', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: false,
-    } as any);
+    mockCanUserViewPII(false);
 
     render(
       <MapPins
@@ -109,9 +111,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should filter out multiple personnel pins when PII cannot be viewed', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: false,
-    } as any);
+    mockCanUserViewPII(false);
 
     const personnelPin2: MapMakerInfoData = {
       ...personnelPin,
@@ -142,9 +142,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should handle different person ImagePath variations', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: false,
-    } as any);
+    mockCanUserViewPII(false);
 
     const personnelPins: MapMakerInfoData[] = [
       { ...personnelPin, Id: '6', Title: 'Person 1', ImagePath: 'person' },
@@ -169,9 +167,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should handle empty pins array', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: false,
-    } as any);
+    mockCanUserViewPII(false);
 
     const { UNSAFE_root } = render(
       <MapPins
@@ -184,9 +180,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should handle pins with undefined or null ImagePath', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: false,
-    } as any);
+    mockCanUserViewPII(false);
 
     const pinWithUndefinedImagePath: MapMakerInfoData = {
       ...callPin,
@@ -214,9 +208,7 @@ describe('MapPins PII Protection', () => {
   });
 
   it('should be case insensitive when filtering personnel pins', () => {
-    mockUseSecurityStore.mockReturnValue({
-      canUserViewPII: false,
-    } as any);
+    mockCanUserViewPII(false);
 
     const personnelPinUppercase: MapMakerInfoData = {
       ...personnelPin,

--- a/src/components/maps/full-screen-location-picker.tsx
+++ b/src/components/maps/full-screen-location-picker.tsx
@@ -43,7 +43,9 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
   const insets = useSafeAreaInsets();
   const mapRef = useRef<Mapbox.MapView>(null);
   const cameraRef = useRef<Mapbox.Camera>(null);
-  const locationStore = useLocationStore();
+  const latitude = useLocationStore((state) => state.latitude);
+  const longitude = useLocationStore((state) => state.longitude);
+  const setLocation = useLocationStore((state) => state.setLocation);
   const [currentLocation, setCurrentLocation] = useState<{
     latitude: number;
     longitude: number;
@@ -161,10 +163,10 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
     try {
       // First try to use stored location from location store
       const storedLocation =
-        locationStore.latitude && locationStore.longitude
+        latitude && longitude
           ? {
-              latitude: locationStore.latitude,
-              longitude: locationStore.longitude,
+              latitude,
+              longitude,
             }
           : null;
 
@@ -219,7 +221,7 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
     } finally {
       if (isMountedRef.current) setIsLoading(false);
     }
-  }, [isMapReady, reverseGeocode, locationStore.latitude, locationStore.longitude, getCurrentLocationFromDevice]);
+  }, [isMapReady, reverseGeocode, latitude, longitude, getCurrentLocationFromDevice]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -246,10 +248,10 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
     } else {
       // Check for stored location from location store
       const storedLocation =
-        locationStore.latitude && locationStore.longitude
+        latitude && longitude
           ? {
-              latitude: locationStore.latitude,
-              longitude: locationStore.longitude,
+              latitude,
+              longitude,
             }
           : null;
 
@@ -274,7 +276,7 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
       // Reset map ready state
       setIsMapReady(false);
     };
-  }, [initialLocation, isMapboxConfigured, reverseGeocode, locationStore.latitude, locationStore.longitude]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialLocation, isMapboxConfigured, reverseGeocode, latitude, longitude]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleMapPress = (event: any) => {
     if (mapError || !isMapboxConfigured) return;
@@ -302,7 +304,7 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
       timestamp: Date.now(),
     } as Location.LocationObject;
 
-    locationStore.setLocation(locationObject);
+    setLocation(locationObject);
   };
 
   const handleConfirmLocation = () => {
@@ -333,7 +335,7 @@ const FullScreenLocationPicker: React.FC<FullScreenLocationPickerProps> = ({ ini
         timestamp: Date.now(),
       } as Location.LocationObject;
 
-      locationStore.setLocation(locationObject);
+      setLocation(locationObject);
 
       onLocationSelected(locationData);
       onClose();

--- a/src/components/maps/map-panel.tsx
+++ b/src/components/maps/map-panel.tsx
@@ -43,12 +43,10 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
   const [mapPins, setMapPins] = useState<MapMakerInfoData[]>([]);
   const [selectedPin, setSelectedPin] = useState<MapMakerInfoData | null>(null);
   const [isPinDetailModalOpen, setIsPinDetailModalOpen] = useState(false);
-  const location = useLocationStore((state) => ({
-    latitude: state.latitude,
-    longitude: state.longitude,
-    heading: state.heading,
-    isMapLocked: state.isMapLocked,
-  }));
+  const latitude = useLocationStore((state) => state.latitude);
+  const longitude = useLocationStore((state) => state.longitude);
+  const heading = useLocationStore((state) => state.heading);
+  const isMapLocked = useLocationStore((state) => state.isMapLocked);
 
   const mapOptions = useMemo(() => {
     return Object.keys(Mapbox.StyleURL)
@@ -61,9 +59,9 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
 
   const styleURL = mapOptions[0]?.data;
   const pulseAnim = useRef(new Animated.Value(1)).current;
-  const isFollowingUser = isScreenFocused && location.isMapLocked && focusedPoi == null;
-  const isInteractionLocked = location.isMapLocked && focusedPoi == null;
-  const showRecenterButton = !isFollowingUser && hasUserMovedMap && location.latitude != null && location.longitude != null;
+  const isFollowingUser = isScreenFocused && isMapLocked && focusedPoi == null;
+  const isInteractionLocked = isMapLocked && focusedPoi == null;
+  const showRecenterButton = !isFollowingUser && hasUserMovedMap && latitude != null && longitude != null;
 
   useMapSignalRUpdates(setMapPins);
 
@@ -80,15 +78,15 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
     useCallback(() => {
       trackEvent('map_viewed', {
         timestamp: new Date().toISOString(),
-        isMapLocked: location.isMapLocked,
-        hasLocation: location.latitude != null && location.longitude != null,
+        isMapLocked: isMapLocked,
+        hasLocation: latitude != null && longitude != null,
       });
 
       if (focusedPoi == null) {
         setHasUserMovedMap(false);
       }
 
-      if (focusedPoi == null && isMapReady && location.latitude != null && location.longitude != null) {
+      if (focusedPoi == null && isMapReady && latitude != null && longitude != null) {
         const cameraConfig: {
           centerCoordinate: [number, number];
           zoomLevel: number;
@@ -96,21 +94,21 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
           heading: number;
           pitch: number;
         } = {
-          centerCoordinate: [location.longitude, location.latitude],
-          zoomLevel: location.isMapLocked ? 16 : 12,
+          centerCoordinate: [longitude, latitude],
+          zoomLevel: isMapLocked ? 16 : 12,
           animationDuration: 1000,
           heading: 0,
           pitch: 0,
         };
 
-        if (location.isMapLocked && location.heading != null) {
-          cameraConfig.heading = location.heading;
+        if (isMapLocked && heading != null) {
+          cameraConfig.heading = heading;
           cameraConfig.pitch = 45;
         }
 
         cameraRef.current?.setCamera(cameraConfig);
       }
-    }, [focusedPoi, isMapReady, location.heading, location.isMapLocked, location.latitude, location.longitude, trackEvent])
+    }, [focusedPoi, isMapReady, heading, isMapLocked, latitude, longitude, trackEvent])
   );
 
   useEffect(() => {
@@ -140,7 +138,7 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
       return;
     }
 
-    if (isMapReady && location.latitude != null && location.longitude != null) {
+    if (isMapReady && latitude != null && longitude != null) {
       if (isFollowingUser || !hasUserMovedMap) {
         const cameraConfig: {
           centerCoordinate: [number, number];
@@ -149,27 +147,27 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
           heading?: number;
           pitch?: number;
         } = {
-          centerCoordinate: [location.longitude, location.latitude],
-          zoomLevel: location.isMapLocked ? 16 : 12,
-          animationDuration: location.isMapLocked ? 500 : 1000,
+          centerCoordinate: [longitude, latitude],
+          zoomLevel: isMapLocked ? 16 : 12,
+          animationDuration: isMapLocked ? 500 : 1000,
         };
 
-        if (location.isMapLocked && location.heading != null) {
-          cameraConfig.heading = location.heading;
+        if (isMapLocked && heading != null) {
+          cameraConfig.heading = heading;
           cameraConfig.pitch = 45;
         }
 
         cameraRef.current?.setCamera(cameraConfig);
       }
     }
-  }, [focusedPoi, hasUserMovedMap, isFollowingUser, isMapReady, isScreenFocused, location.heading, location.isMapLocked, location.latitude, location.longitude]);
+  }, [focusedPoi, hasUserMovedMap, isFollowingUser, isMapReady, isScreenFocused, heading, isMapLocked, latitude, longitude]);
 
   useEffect(() => {
     if (focusedPoi != null) {
       return;
     }
 
-    if (location.isMapLocked) {
+    if (isMapLocked) {
       setHasUserMovedMap(false);
       return;
     }
@@ -177,16 +175,16 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
     setHasUserMovedMap(false);
 
     // Only drive the camera while focused — see isScreenFocused note above.
-    if (isScreenFocused && isMapReady && location.latitude != null && location.longitude != null) {
+    if (isScreenFocused && isMapReady && latitude != null && longitude != null) {
       cameraRef.current?.setCamera({
-        centerCoordinate: [location.longitude, location.latitude],
+        centerCoordinate: [longitude, latitude],
         zoomLevel: 12,
         heading: 0,
         pitch: 0,
         animationDuration: 1000,
       });
     }
-  }, [focusedPoi, isMapReady, isScreenFocused, location.isMapLocked, location.latitude, location.longitude]);
+  }, [focusedPoi, isMapReady, isScreenFocused, isMapLocked, latitude, longitude]);
 
   useEffect(() => {
     let isMounted = true;
@@ -244,7 +242,7 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
   );
 
   const handleRecenterMap = useCallback(() => {
-    if (location.latitude != null && location.longitude != null) {
+    if (latitude != null && longitude != null) {
       const cameraConfig: {
         centerCoordinate: [number, number];
         zoomLevel: number;
@@ -252,13 +250,13 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
         heading?: number;
         pitch?: number;
       } = {
-        centerCoordinate: [location.longitude, location.latitude],
-        zoomLevel: location.isMapLocked ? 16 : 12,
+        centerCoordinate: [longitude, latitude],
+        zoomLevel: isMapLocked ? 16 : 12,
         animationDuration: 1000,
       };
 
-      if (location.isMapLocked && location.heading != null) {
-        cameraConfig.heading = location.heading;
+      if (isMapLocked && heading != null) {
+        cameraConfig.heading = heading;
         cameraConfig.pitch = 45;
       }
 
@@ -267,11 +265,11 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
 
       trackEvent('map_recentered', {
         timestamp: new Date().toISOString(),
-        isMapLocked: location.isMapLocked,
-        zoomLevel: location.isMapLocked ? 16 : 12,
+        isMapLocked: isMapLocked,
+        zoomLevel: isMapLocked ? 16 : 12,
       });
     }
-  }, [location.heading, location.isMapLocked, location.latitude, location.longitude, trackEvent]);
+  }, [heading, isMapLocked, latitude, longitude, trackEvent]);
 
   const handlePinPress = useCallback(
     (pin: MapMakerInfoData) => {
@@ -342,14 +340,14 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
       >
         <Mapbox.Camera
           ref={cameraRef}
-          followZoomLevel={location.isMapLocked ? 16 : 12}
+          followZoomLevel={isMapLocked ? 16 : 12}
           followUserLocation={isFollowingUser}
           {...(isFollowingUser ? { followUserMode: Mapbox.UserTrackingMode.FollowWithHeading } : {})}
           {...(isFollowingUser ? { followPitch: 45 } : {})}
         />
 
-        {location.latitude != null && location.longitude != null ? (
-          <Mapbox.PointAnnotation id="userLocation" coordinate={[location.longitude, location.latitude]} anchor={{ x: 0.5, y: 0.5 }}>
+        {latitude != null && longitude != null ? (
+          <Mapbox.PointAnnotation id="userLocation" coordinate={[longitude, latitude]} anchor={{ x: 0.5, y: 0.5 }}>
             <Animated.View
               style={[
                 styles.markerContainer,
@@ -361,12 +359,12 @@ export const MapPanel: React.FC<MapPanelProps> = ({ focusedPoi }) => {
               <View style={styles.markerOuterRing} />
               <View style={styles.markerInnerContainer}>
                 <View style={styles.markerDot} />
-                {location.heading != null ? (
+                {heading != null ? (
                   <View
                     style={[
                       styles.directionIndicator,
                       {
-                        transform: [{ rotate: `${location.heading}deg` }],
+                        transform: [{ rotate: `${heading}deg` }],
                       },
                     ]}
                   />

--- a/src/components/maps/map-pins.tsx
+++ b/src/components/maps/map-pins.tsx
@@ -1,18 +1,23 @@
 import Mapbox from '@rnmapbox/maps';
 import { useColorScheme } from 'nativewind';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text } from 'react-native';
 
 import { POI_MARKER_HEIGHT, POI_MARKER_WIDTH } from '@/constants/poi-marker-shapes';
 import { isPoiMarker } from '@/lib/poi';
 import { type MapMakerInfoData } from '@/models/v4/mapping/getMapDataAndMarkersData';
-import { useSecurityStore } from '@/stores/security/store';
+import { securityStore } from '@/stores/security/store';
 
 import PinMarker from './pin-marker';
 import PoiPinMarker from './poi-pin-marker';
 
 interface MapPinsProps {
   pins: MapMakerInfoData[];
+  onPinPress?: (pin: MapMakerInfoData) => void;
+}
+
+interface PinItemProps {
+  pin: MapMakerInfoData;
   onPinPress?: (pin: MapMakerInfoData) => void;
 }
 
@@ -27,50 +32,56 @@ const PoiTitle: React.FC<{ title: string }> = ({ title }) => {
   );
 };
 
-const MapPins: React.FC<MapPinsProps> = ({ pins, onPinPress }) => {
-  const { canUserViewPII } = useSecurityStore();
-
-  // Filter out personnel pins if user cannot view PII
-  const filteredPins = pins.filter((pin) => {
-    // Check if this is a personnel pin by ImagePath
-    const isPersonnelPin = pin.ImagePath && pin.ImagePath.toLowerCase().startsWith('person');
-
-    // If it's a personnel pin and user can't view PII, filter it out
-    if (isPersonnelPin && !canUserViewPII) {
-      return false;
-    }
-
-    return true;
-  });
+const PoiPinItem = React.memo<PinItemProps>(({ pin, onPinPress }) => {
+  const handlePress = useCallback(() => onPinPress?.(pin), [onPinPress, pin]);
 
   return (
     <>
-      {filteredPins.map((pin) => {
-        if (isPoiMarker(pin)) {
-          return (
-            <React.Fragment key={`poi-group-${pin.Id}`}>
-              {/* Shape + icon: 36x48 exact dimensions, anchor at bottom-center tip */}
-              <Mapbox.MarkerView key={`poi-${pin.Id}`} id={`poi-${pin.Id}`} coordinate={[pin.Longitude, pin.Latitude]} anchor={{ x: 0.5, y: 1 }} allowOverlap={true}>
-                <PoiPinMarker color={pin.Color} poiImage={pin.PoiImage} imagePath={pin.ImagePath} marker={pin.Marker} title={pin.Title} onPress={() => onPinPress?.(pin)} />
-              </Mapbox.MarkerView>
-              {/* Title label: separate MarkerView so it does NOT affect shape anchor measurement */}
-              {pin.Title ? (
-                <Mapbox.MarkerView key={`poi-title-${pin.Id}`} id={`poi-title-${pin.Id}`} coordinate={[pin.Longitude, pin.Latitude]} anchor={{ x: 0.5, y: -0.05 }} allowOverlap={true}>
-                  <PoiTitle title={pin.Title} />
-                </Mapbox.MarkerView>
-              ) : null}
-            </React.Fragment>
-          );
-        }
-
-        return (
-          <Mapbox.MarkerView key={`pin-${pin.Id}`} id={`pin-${pin.Id}`} coordinate={[pin.Longitude, pin.Latitude]} anchor={{ x: 0.5, y: 0.5 }} allowOverlap={true}>
-            <PinMarker imagePath={pin.ImagePath} poiImage={pin.PoiImage} marker={pin.Marker} fallbackIconKey={pin.Type === 4 ? 'flag' : 'call'} title={pin.Title} size={32} onPress={() => onPinPress?.(pin)} />
-          </Mapbox.MarkerView>
-        );
-      })}
+      {/* Shape + icon: 36x48 exact dimensions, anchor at bottom-center tip */}
+      <Mapbox.MarkerView id={`poi-${pin.Id}`} coordinate={[pin.Longitude, pin.Latitude]} anchor={{ x: 0.5, y: 1 }} allowOverlap={true}>
+        <PoiPinMarker color={pin.Color} poiImage={pin.PoiImage} imagePath={pin.ImagePath} marker={pin.Marker} title={pin.Title} onPress={handlePress} />
+      </Mapbox.MarkerView>
+      {/* Title label: separate MarkerView so it does NOT affect shape anchor measurement */}
+      {pin.Title ? (
+        <Mapbox.MarkerView id={`poi-title-${pin.Id}`} coordinate={[pin.Longitude, pin.Latitude]} anchor={{ x: 0.5, y: -0.05 }} allowOverlap={true}>
+          <PoiTitle title={pin.Title} />
+        </Mapbox.MarkerView>
+      ) : null}
     </>
   );
+});
+
+const StandardPinItem = React.memo<PinItemProps>(({ pin, onPinPress }) => {
+  const handlePress = useCallback(() => onPinPress?.(pin), [onPinPress, pin]);
+
+  return (
+    <Mapbox.MarkerView id={`pin-${pin.Id}`} coordinate={[pin.Longitude, pin.Latitude]} anchor={{ x: 0.5, y: 0.5 }} allowOverlap={true}>
+      <PinMarker imagePath={pin.ImagePath} poiImage={pin.PoiImage} marker={pin.Marker} fallbackIconKey={pin.Type === 4 ? 'flag' : 'call'} title={pin.Title} size={32} onPress={handlePress} />
+    </Mapbox.MarkerView>
+  );
+});
+
+const MapPins: React.FC<MapPinsProps> = ({ pins, onPinPress }) => {
+  const canUserViewPII = securityStore((state) => state.rights?.CanViewPII);
+
+  // Filter out personnel pins if user cannot view PII
+  const filteredPins = useMemo(
+    () =>
+      pins.filter((pin) => {
+        // Check if this is a personnel pin by ImagePath
+        const isPersonnelPin = pin.ImagePath && pin.ImagePath.toLowerCase().startsWith('person');
+
+        // If it's a personnel pin and user can't view PII, filter it out
+        if (isPersonnelPin && !canUserViewPII) {
+          return false;
+        }
+
+        return true;
+      }),
+    [pins, canUserViewPII]
+  );
+
+  return <>{filteredPins.map((pin) => (isPoiMarker(pin) ? <PoiPinItem key={`poi-group-${pin.Id}`} pin={pin} onPinPress={onPinPress} /> : <StandardPinItem key={`pin-${pin.Id}`} pin={pin} onPinPress={onPinPress} />))}</>;
 };
 
 const styles = StyleSheet.create({
@@ -82,4 +93,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default MapPins;
+export default React.memo(MapPins);

--- a/src/components/maps/pin-detail-modal.tsx
+++ b/src/components/maps/pin-detail-modal.tsx
@@ -16,7 +16,7 @@ import { VStack } from '@/components/ui/vstack';
 import { openMapsWithDirections } from '@/lib/navigation';
 import { type MapMakerInfoData } from '@/models/v4/mapping/getMapDataAndMarkersData';
 import { useLocationStore } from '@/stores/app/location-store';
-import { useSecurityStore } from '@/stores/security/store';
+import { securityStore } from '@/stores/security/store';
 import { useToastStore } from '@/stores/toast/store';
 
 interface PinDetailModalProps {
@@ -30,12 +30,10 @@ export const PinDetailModal: React.FC<PinDetailModalProps> = ({ pin, isOpen, onC
   const { t } = useTranslation();
   const { colorScheme } = useColorScheme();
   const router = useRouter();
-  const { canUserViewPII } = useSecurityStore();
+  const canUserViewPII = securityStore((state) => state.rights?.CanViewPII);
   const showToast = useToastStore((state) => state.showToast);
-  const userLocation = useLocationStore((state) => ({
-    latitude: state.latitude,
-    longitude: state.longitude,
-  }));
+  const userLatitude = useLocationStore((state) => state.latitude);
+  const userLongitude = useLocationStore((state) => state.longitude);
 
   if (!pin) return null;
 
@@ -57,7 +55,7 @@ export const PinDetailModal: React.FC<PinDetailModalProps> = ({ pin, isOpen, onC
     }
 
     try {
-      const success = await openMapsWithDirections(pin.Latitude, pin.Longitude, pin.Title, userLocation.latitude || undefined, userLocation.longitude || undefined);
+      const success = await openMapsWithDirections(pin.Latitude, pin.Longitude, pin.Title, userLatitude || undefined, userLongitude || undefined);
 
       if (!success) {
         showToast('error', t('map.failed_to_open_maps'));

--- a/src/components/maps/pin-marker.tsx
+++ b/src/components/maps/pin-marker.tsx
@@ -49,4 +49,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default PinMarker;
+export default React.memo(PinMarker);

--- a/src/components/notifications/NotificationInbox.tsx
+++ b/src/components/notifications/NotificationInbox.tsx
@@ -79,13 +79,16 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
     }
   }, [isOpen, slideAnim, fadeAnim]);
 
-  const handleNotificationPress = (notification: NotificationPayload) => {
-    if (isSelectionMode) {
-      toggleNotificationSelection(notification.id);
-    } else {
-      setSelectedNotification(notification);
-    }
-  };
+  const handleNotificationPress = React.useCallback(
+    (notification: NotificationPayload) => {
+      if (isSelectionMode) {
+        toggleNotificationSelection(notification.id);
+      } else {
+        setSelectedNotification(notification);
+      }
+    },
+    [isSelectionMode]
+  );
 
   const toggleNotificationSelection = (notificationId: string) => {
     setSelectedNotificationIds((prev) => {
@@ -161,68 +164,74 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
     [showToast, refetch, t]
   );
 
-  const handleNavigateToReference = (referenceType: string, referenceId: string) => {
-    // TODO: Implement navigation based on reference type
-    console.log('Navigate to:', referenceType, referenceId);
-    onClose();
-  };
+  const handleNavigateToReference = React.useCallback(
+    (referenceType: string, referenceId: string) => {
+      // TODO: Implement navigation based on reference type
+      console.log('Navigate to:', referenceType, referenceId);
+      onClose();
+    },
+    [onClose]
+  );
 
-  const renderItem = ({ item }: { item: any }) => {
-    const notification: NotificationPayload = {
-      id: item.id,
-      title: item.title,
-      body: item.body,
-      createdAt: item.createdAt,
-      read: item.read,
-      type: item.type,
-      referenceId: item.payload?.referenceId,
-      referenceType: item.payload?.referenceType,
-      metadata: item.payload?.metadata,
-    };
+  const renderItem = React.useCallback(
+    ({ item }: { item: any }) => {
+      const notification: NotificationPayload = {
+        id: item.id,
+        title: item.title,
+        body: item.body,
+        createdAt: item.createdAt,
+        read: item.read,
+        type: item.type,
+        referenceId: item.payload?.referenceId,
+        referenceType: item.payload?.referenceType,
+        metadata: item.payload?.metadata,
+      };
 
-    const isSelected = selectedNotificationIds.has(notification.id);
+      const isSelected = selectedNotificationIds.has(notification.id);
 
-    return (
-      <Pressable
-        onPress={() => handleNotificationPress(notification)}
-        onLongPress={() => {
-          if (!isSelectionMode) {
-            enterSelectionMode();
-            toggleNotificationSelection(notification.id);
-          }
-        }}
-        style={[styles.notificationItem, !item.read ? styles.unreadNotificationItem : {}, isSelected ? styles.selectedNotificationItem : {}]}
-      >
-        {!item.read ? <View style={styles.unreadIndicator} /> : null}
+      return (
+        <Pressable
+          onPress={() => handleNotificationPress(notification)}
+          onLongPress={() => {
+            if (!isSelectionMode) {
+              enterSelectionMode();
+              toggleNotificationSelection(notification.id);
+            }
+          }}
+          style={[styles.notificationItem, !item.read ? styles.unreadNotificationItem : {}, isSelected ? styles.selectedNotificationItem : {}]}
+        >
+          {!item.read ? <View style={styles.unreadIndicator} /> : null}
 
-        {isSelectionMode ? (
-          <View style={styles.selectionIndicator}>
-            {isSelected ? <CheckCircle size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} /> : <Circle size={24} className="text-gray-400 dark:text-gray-500" strokeWidth={2} />}
-          </View>
-        ) : null}
-
-        <View style={styles.notificationContent}>
-          <Text style={[styles.notificationBody, !item.read ? styles.unreadNotificationText : {}]}>{notification.body}</Text>
-          <Text style={styles.timestamp}>
-            {new Date(notification.createdAt).toLocaleDateString()} {new Date(notification.createdAt).toLocaleTimeString()}
-          </Text>
-        </View>
-
-        {!isSelectionMode ? (
-          notification.referenceType && notification.referenceId ? (
-            <View style={styles.actionButtons}>
-              <Button onPress={() => handleNavigateToReference(notification.referenceType!, notification.referenceId!)} variant="outline" className="size-8 p-0">
-                <ExternalLink size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} />
-              </Button>
-              <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
+          {isSelectionMode ? (
+            <View style={styles.selectionIndicator}>
+              {isSelected ? <CheckCircle size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} /> : <Circle size={24} className="text-gray-400 dark:text-gray-500" strokeWidth={2} />}
             </View>
-          ) : (
-            <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
-          )
-        ) : null}
-      </Pressable>
-    );
-  };
+          ) : null}
+
+          <View style={styles.notificationContent}>
+            <Text style={[styles.notificationBody, !item.read ? styles.unreadNotificationText : {}]}>{notification.body}</Text>
+            <Text style={styles.timestamp}>
+              {new Date(notification.createdAt).toLocaleDateString()} {new Date(notification.createdAt).toLocaleTimeString()}
+            </Text>
+          </View>
+
+          {!isSelectionMode ? (
+            notification.referenceType && notification.referenceId ? (
+              <View style={styles.actionButtons}>
+                <Button onPress={() => handleNavigateToReference(notification.referenceType!, notification.referenceId!)} variant="outline" className="size-8 p-0">
+                  <ExternalLink size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} />
+                </Button>
+                <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
+              </View>
+            ) : (
+              <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
+            )
+          ) : null}
+        </Pressable>
+      );
+    },
+    [isSelectionMode, selectedNotificationIds, handleNotificationPress, handleNavigateToReference]
+  );
 
   const renderFooter = () => {
     if (!hasMore) return null;

--- a/src/components/notifications/NotificationInbox.tsx
+++ b/src/components/notifications/NotificationInbox.tsx
@@ -188,6 +188,7 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
       };
 
       const isSelected = selectedNotificationIds.has(notification.id);
+      const createdAt = new Date(notification.createdAt);
 
       return (
         <Pressable
@@ -211,7 +212,7 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
           <View style={styles.notificationContent}>
             <Text style={[styles.notificationBody, !item.read ? styles.unreadNotificationText : {}]}>{notification.body}</Text>
             <Text style={styles.timestamp}>
-              {new Date(notification.createdAt).toLocaleDateString()} {new Date(notification.createdAt).toLocaleTimeString()}
+              {createdAt.toLocaleDateString()} {createdAt.toLocaleTimeString()}
             </Text>
           </View>
 

--- a/src/components/personnel/__tests__/personnel-details-sheet.test.tsx
+++ b/src/components/personnel/__tests__/personnel-details-sheet.test.tsx
@@ -102,7 +102,7 @@ const mockSecurityStore = {
 };
 
 jest.mock('@/stores/security/store', () => ({
-  useSecurityStore: () => mockSecurityStore,
+  securityStore: (selector: any) => selector({ rights: { CanViewPII: mockSecurityStore.canUserViewPII } }),
 }));
 
 // Mock translation

--- a/src/components/personnel/personnel-card.tsx
+++ b/src/components/personnel/personnel-card.tsx
@@ -18,7 +18,7 @@ interface PersonnelCardProps {
   onPress: (id: string) => void;
 }
 
-export const PersonnelCard: React.FC<PersonnelCardProps> = ({ personnel, onPress }) => {
+export const PersonnelCard: React.FC<PersonnelCardProps> = React.memo(function PersonnelCard({ personnel, onPress }) {
   const fullName = `${personnel.FirstName} ${personnel.LastName}`.trim();
   const { canUserViewPII } = useSecurityStore();
   const [imageError, setImageError] = React.useState(false);
@@ -122,4 +122,4 @@ export const PersonnelCard: React.FC<PersonnelCardProps> = ({ personnel, onPress
       </Box>
     </Pressable>
   );
-};
+});

--- a/src/components/personnel/personnel-details-sheet.tsx
+++ b/src/components/personnel/personnel-details-sheet.tsx
@@ -6,7 +6,7 @@ import { ScrollView } from 'react-native';
 import { useAnalytics } from '@/hooks/use-analytics';
 import { formatDateForDisplay, getAvatarUrl, getColorFromString, getInitials, parseDateISOString, safeFormatTimestamp } from '@/lib/utils';
 import { usePersonnelStore } from '@/stores/personnel/store';
-import { useSecurityStore } from '@/stores/security/store';
+import { securityStore } from '@/stores/security/store';
 
 import { Actionsheet, ActionsheetBackdrop, ActionsheetContent, ActionsheetDragIndicator, ActionsheetDragIndicatorWrapper } from '../ui/actionsheet';
 import { Avatar, AvatarFallbackText, AvatarImage } from '../ui/avatar';
@@ -22,7 +22,7 @@ import { VStack } from '../ui/vstack';
 export const PersonnelDetailsSheet: React.FC = () => {
   const { t } = useTranslation();
   const { personnel, selectedPersonnelId, isDetailsOpen, closeDetails } = usePersonnelStore();
-  const { canUserViewPII } = useSecurityStore();
+  const canUserViewPII = securityStore((state) => state.rights?.CanViewPII);
   const { trackEvent } = useAnalytics();
   const [imageError, setImageError] = useState(false);
 

--- a/src/components/sidebar/__tests__/side-menu.test.tsx
+++ b/src/components/sidebar/__tests__/side-menu.test.tsx
@@ -6,7 +6,7 @@ import { useColorScheme } from 'nativewind';
 import { SideMenu } from '../side-menu';
 import { useLiveKitStore } from '@/stores/app/livekit-store';
 import { useAudioStreamStore } from '@/stores/app/audio-stream-store';
-import { useSecurityStore, securityStore } from '@/stores/security/store';
+import { securityStore } from '@/stores/security/store';
 
 // Mock dependencies
 jest.mock('expo-router', () => ({
@@ -27,13 +27,14 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@/lib/auth', () => ({
-  useAuthStore: () => ({
-    profile: {
-      name: 'Test User',
-      sub: '12345678',
-    },
-    logout: jest.fn(),
-  }),
+  useAuthStore: (selector: (state: { profile: { name: string; sub: string }; logout: jest.Mock }) => unknown) =>
+    selector({
+      profile: {
+        name: 'Test User',
+        sub: '12345678',
+      },
+      logout: jest.fn(),
+    }),
 }));
 
 jest.mock('@/stores/app/livekit-store', () => ({
@@ -188,8 +189,11 @@ jest.mock('@/components/ui/vstack', () => {
 const mockUseLiveKitStore = useLiveKitStore as jest.MockedFunction<typeof useLiveKitStore>;
 const mockUseAudioStreamStore = useAudioStreamStore as jest.MockedFunction<typeof useAudioStreamStore>;
 const mockUseColorScheme = useColorScheme as jest.MockedFunction<typeof useColorScheme>;
-const mockUseSecurityStore = useSecurityStore as jest.MockedFunction<typeof useSecurityStore>;
 const mockSecurityStore = securityStore as jest.MockedFunction<typeof securityStore>;
+
+const mockStore = (mockFn: jest.MockedFunction<any>, state: object) => {
+  mockFn.mockImplementation((selector: (s: object) => unknown) => selector(state));
+};
 
 describe('SideMenu', () => {
   const mockSetIsBottomSheetVisible = jest.fn();
@@ -205,26 +209,13 @@ describe('SideMenu', () => {
     });
 
     // Default audio stream store mock
-    mockUseAudioStreamStore.mockReturnValue({
+    mockStore(mockUseAudioStreamStore, {
       currentStream: null,
       isPlaying: false,
       setIsBottomSheetVisible: mockSetAudioStreamBottomSheetVisible,
     });
 
-    // Default security store mock
-    mockUseSecurityStore.mockReturnValue({
-      error: null,
-      getRights: jest.fn(),
-      isUserDepartmentAdmin: false,
-      isUserGroupAdmin: jest.fn().mockReturnValue(false),
-      canUserCreateCalls: false,
-      canUserCreateNotes: false,
-      canUserCreateMessages: false,
-      canUserViewPII: false,
-      departmentCode: 'TEST',
-    });
-
-    mockSecurityStore.mockReturnValue({
+    mockStore(mockSecurityStore, {
       rights: {
         FullName: 'John Doe',
         DepartmentName: 'Fire Department',
@@ -244,7 +235,7 @@ describe('SideMenu', () => {
   });
 
   it('should render PTT button with normal styling when not connected to voice call', () => {
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: false,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -262,7 +253,7 @@ describe('SideMenu', () => {
   });
 
   it('should render PTT button with active styling when connected to voice call', () => {
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: true,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -280,7 +271,7 @@ describe('SideMenu', () => {
   });
 
   it('should open LiveKit bottom sheet when PTT button is pressed and not connected', () => {
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: false,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -296,7 +287,7 @@ describe('SideMenu', () => {
   });
 
   it('should open LiveKit bottom sheet when PTT button is pressed and connected', () => {
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: true,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -317,7 +308,7 @@ describe('SideMenu', () => {
       setColorScheme: jest.fn(),
       toggleColorScheme: jest.fn(),
     });
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: false,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -340,7 +331,7 @@ describe('SideMenu', () => {
       setColorScheme: jest.fn(),
       toggleColorScheme: jest.fn(),
     });
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: true,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -357,7 +348,7 @@ describe('SideMenu', () => {
   });
 
   it('should render profile section correctly', () => {
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: false,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -371,7 +362,7 @@ describe('SideMenu', () => {
   });
 
   it('should render all navigation menu items', () => {
-    mockUseLiveKitStore.mockReturnValue({
+    mockStore(mockUseLiveKitStore, {
       isConnected: false,
       setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
       toggleMicrophone: mockToggleMicrophone,
@@ -393,13 +384,13 @@ describe('SideMenu', () => {
 
   describe('Audio Stream Button', () => {
     it('should render with outline styling when no stream is playing', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockUseAudioStreamStore.mockReturnValue({
+      mockStore(mockUseAudioStreamStore, {
         currentStream: null,
         isPlaying: false,
         setIsBottomSheetVisible: mockSetAudioStreamBottomSheetVisible,
@@ -417,13 +408,13 @@ describe('SideMenu', () => {
     });
 
     it('should render with filled styling when stream is playing', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockUseAudioStreamStore.mockReturnValue({
+      mockStore(mockUseAudioStreamStore, {
         currentStream: { Id: '1', Name: 'Test Stream' },
         isPlaying: true,
         setIsBottomSheetVisible: mockSetAudioStreamBottomSheetVisible,
@@ -441,13 +432,13 @@ describe('SideMenu', () => {
     });
 
     it('should open audio stream bottom sheet when pressed', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockUseAudioStreamStore.mockReturnValue({
+      mockStore(mockUseAudioStreamStore, {
         currentStream: null,
         isPlaying: false,
         setIsBottomSheetVisible: mockSetAudioStreamBottomSheetVisible,
@@ -462,13 +453,13 @@ describe('SideMenu', () => {
     });
 
     it('should re-open audio stream bottom sheet when pressed while playing', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockUseAudioStreamStore.mockReturnValue({
+      mockStore(mockUseAudioStreamStore, {
         currentStream: { Id: '1', Name: 'Test Stream' },
         isPlaying: true,
         setIsBottomSheetVisible: mockSetAudioStreamBottomSheetVisible,
@@ -485,13 +476,13 @@ describe('SideMenu', () => {
 
   describe('Profile Section', () => {
     it('should display FullName from security store when available', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockSecurityStore.mockReturnValue({
+      mockStore(mockSecurityStore, {
         rights: {
           FullName: 'Jane Smith',
           DepartmentName: 'Police Department',
@@ -517,13 +508,13 @@ describe('SideMenu', () => {
     });
 
     it('should display DepartmentName from security store when available', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockSecurityStore.mockReturnValue({
+      mockStore(mockSecurityStore, {
         rights: {
           FullName: 'Bob Johnson',
           DepartmentName: 'Emergency Services',
@@ -548,13 +539,13 @@ describe('SideMenu', () => {
     });
 
     it('should fallback to profile name when security store FullName is not available', () => {
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: mockSetIsBottomSheetVisible,
         toggleMicrophone: mockToggleMicrophone,
       });
 
-      mockSecurityStore.mockReturnValue({
+      mockStore(mockSecurityStore, {
         rights: null,
         error: null,
         getRights: jest.fn(),
@@ -574,14 +565,14 @@ describe('SideMenu', () => {
 
       // Reset all mocks to ensure proper setup
       const mockUseLiveKitStore = useLiveKitStore as jest.MockedFunction<typeof useLiveKitStore>;
-      mockUseLiveKitStore.mockReturnValue({
+      mockStore(mockUseLiveKitStore, {
         isConnected: false,
         setIsBottomSheetVisible: jest.fn(),
         toggleMicrophone: jest.fn(),
       });
 
       const mockUseAudioStreamStore = useAudioStreamStore as jest.MockedFunction<typeof useAudioStreamStore>;
-      mockUseAudioStreamStore.mockReturnValue({
+      mockStore(mockUseAudioStreamStore, {
         currentStream: null,
         isPlaying: false,
         setIsBottomSheetVisible: jest.fn(),

--- a/src/components/sidebar/side-menu.tsx
+++ b/src/components/sidebar/side-menu.tsx
@@ -16,7 +16,7 @@ import { useAuthStore } from '@/lib/auth';
 import { getAvatarUrl } from '@/lib/utils';
 import { useAudioStreamStore } from '@/stores/app/audio-stream-store';
 import { useLiveKitStore } from '@/stores/app/livekit-store';
-import { securityStore, useSecurityStore } from '@/stores/security/store';
+import { securityStore } from '@/stores/security/store';
 
 import { AudioStreamBottomSheet } from '../audio-stream/audio-stream-bottom-sheet';
 
@@ -36,11 +36,14 @@ export const SideMenu: React.FC<SideMenuProps> = React.memo(({ onNavigate }) => 
   const { t } = useTranslation();
   const { colorScheme } = useColorScheme();
   const router = useRouter();
-  const { profile, logout } = useAuthStore();
-  const { isConnected, setIsBottomSheetVisible } = useLiveKitStore();
-  const { currentStream, isPlaying, setIsBottomSheetVisible: setAudioStreamBottomSheetVisible } = useAudioStreamStore();
-  const { departmentCode } = useSecurityStore();
-  const securityStoreState = securityStore();
+  const profile = useAuthStore((state) => state.profile);
+  const logout = useAuthStore((state) => state.logout);
+  const isConnected = useLiveKitStore((state) => state.isConnected);
+  const setIsBottomSheetVisible = useLiveKitStore((state) => state.setIsBottomSheetVisible);
+  const currentStream = useAudioStreamStore((state) => state.currentStream);
+  const isPlaying = useAudioStreamStore((state) => state.isPlaying);
+  const setAudioStreamBottomSheetVisible = useAudioStreamStore((state) => state.setIsBottomSheetVisible);
+  const rights = securityStore((state) => state.rights);
 
   const menuItems: MenuItem[] = useMemo(
     () => [
@@ -141,8 +144,8 @@ export const SideMenu: React.FC<SideMenuProps> = React.memo(({ onNavigate }) => 
   }, []);
 
   // Get user display name and department name from security store
-  const displayName = securityStoreState.rights?.FullName || profile?.name || t('common.unknown_user');
-  const departmentName = securityStoreState.rights?.DepartmentName || t('common.unknown_department');
+  const displayName = rights?.FullName || profile?.name || t('common.unknown_user');
+  const departmentName = rights?.DepartmentName || t('common.unknown_department');
 
   const isDark = colorScheme === 'dark';
 

--- a/src/components/units/unit-card.tsx
+++ b/src/components/units/unit-card.tsx
@@ -78,7 +78,7 @@ interface UnitCardProps {
   onPress: (id: string) => void;
 }
 
-export const UnitCard: React.FC<UnitCardProps> = ({ unit, unitTypeStatuses, onPress }) => {
+export const UnitCard: React.FC<UnitCardProps> = React.memo(function UnitCard({ unit, unitTypeStatuses, onPress }) {
   const { t } = useTranslation();
   const hasLocation = unit.Latitude && unit.Longitude;
 
@@ -163,4 +163,4 @@ export const UnitCard: React.FC<UnitCardProps> = ({ unit, unitTypeStatuses, onPr
       </Box>
     </Pressable>
   );
-};
+});

--- a/src/hooks/__tests__/use-oidc-login.test.ts
+++ b/src/hooks/__tests__/use-oidc-login.test.ts
@@ -33,7 +33,7 @@ jest.mock('@/stores/auth/store', () => {
 });
 
 import useAuthStore from '@/stores/auth/store';
-import { useOidcLogin } from '../use-oidc-login';
+import { isValidSsoUrl, useOidcLogin } from '../use-oidc-login';
 
 // Access mockLoginWithSso via the attached property
 const mockLoginWithSso: jest.Mock = (useAuthStore as any).__loginWithSso;
@@ -41,6 +41,33 @@ const mockLoginWithSso: jest.Mock = (useAuthStore as any).__loginWithSso;
 const mockedUseAuthRequest = AuthSession.useAuthRequest as jest.Mock;
 const mockedUseAutoDiscovery = AuthSession.useAutoDiscovery as jest.Mock;
 const mockedExchangeCodeAsync = AuthSession.exchangeCodeAsync as jest.Mock;
+
+describe('isValidSsoUrl', () => {
+  it('accepts well-formed https URLs', () => {
+    expect(isValidSsoUrl('https://idp.example.com')).toBe(true);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isValidSsoUrl('not a url')).toBe(false);
+    expect(isValidSsoUrl('')).toBe(false);
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    expect(isValidSsoUrl('ftp://idp.example.com')).toBe(false);
+    expect(isValidSsoUrl('resgrid://auth/callback')).toBe(false);
+  });
+
+  it('rejects http URLs when not in dev mode', () => {
+    const originalDev = (global as Record<string, unknown>).__DEV__;
+    (global as Record<string, unknown>).__DEV__ = false;
+
+    try {
+      expect(isValidSsoUrl('http://idp.example.com')).toBe(false);
+    } finally {
+      (global as Record<string, unknown>).__DEV__ = originalDev;
+    }
+  });
+});
 
 describe('useOidcLogin', () => {
   beforeEach(() => {
@@ -58,6 +85,22 @@ describe('useOidcLogin', () => {
 
     expect(result.current.request).toBeNull();
     expect(result.current.response).toBeNull();
+  });
+
+  it('passes an empty authority to discovery when the authority URL is invalid', () => {
+    renderHook(() =>
+      useOidcLogin({ authority: 'not a url', clientId: 'test', departmentCode: 'DEPT' }),
+    );
+
+    expect(mockedUseAutoDiscovery).toHaveBeenCalledWith('');
+  });
+
+  it('passes the authority to discovery when the authority URL is valid https', () => {
+    renderHook(() =>
+      useOidcLogin({ authority: 'https://idp.example.com', clientId: 'test', departmentCode: 'DEPT' }),
+    );
+
+    expect(mockedUseAutoDiscovery).toHaveBeenCalledWith('https://idp.example.com');
   });
 
   it('exchangeCodeForResgridToken returns false when response type is not success', async () => {

--- a/src/hooks/__tests__/use-saml-login.test.ts
+++ b/src/hooks/__tests__/use-saml-login.test.ts
@@ -1,7 +1,9 @@
+import { renderHook, act } from '@testing-library/react-native';
 import * as Linking from 'expo-linking';
+import * as SecureStore from 'expo-secure-store';
 import * as WebBrowser from 'expo-web-browser';
 
-import { handleSamlCallbackUrl, PENDING_SAML_DEPT_CODE_KEY } from '../use-saml-login';
+import { handleSamlCallbackUrl, PENDING_SAML_DEPT_CODE_KEY, useSamlLogin } from '../use-saml-login';
 
 // Mock expo modules
 jest.mock('expo-linking', () => ({
@@ -10,6 +12,27 @@ jest.mock('expo-linking', () => ({
 
 jest.mock('expo-web-browser', () => ({
   openBrowserAsync: jest.fn(),
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+jest.mock('expo-auth-session', () => ({
+  makeRedirectUri: jest.fn().mockReturnValue('resgrid://auth/callback'),
+  useAutoDiscovery: jest.fn().mockReturnValue(null),
+  useAuthRequest: jest.fn().mockReturnValue([null, null, jest.fn()]),
+  ResponseType: { Code: 'code' },
+}));
+
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn().mockReturnValue('test-state-uuid'),
+}));
+
+const mockSecureGetItemAsync = jest.fn();
+const mockSecureSetItemAsync = jest.fn().mockResolvedValue(undefined);
+const mockSecureDeleteItemAsync = jest.fn().mockResolvedValue(undefined);
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: (...args: any[]) => mockSecureGetItemAsync(...args),
+  setItemAsync: (...args: any[]) => mockSecureSetItemAsync(...args),
+  deleteItemAsync: (...args: any[]) => mockSecureDeleteItemAsync(...args),
 }));
 
 // Mock storage
@@ -40,18 +63,25 @@ jest.mock('@/stores/auth/store', () => {
   return {
     __esModule: true,
     default: storeMock,
+    PENDING_SAML_STATE_KEY: 'pending_saml_state',
   };
 });
 
+import { logger } from '@/lib/logging';
 import useAuthStore from '@/stores/auth/store';
 
 const mockedParse = Linking.parse as jest.Mock;
+const mockedOpenBrowserAsync = WebBrowser.openBrowserAsync as jest.Mock;
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+const validPendingState = (createdAt: number = Date.now(), state: string = 'test-state-uuid') => JSON.stringify({ state, createdAt });
 
 describe('handleSamlCallbackUrl', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Re-bind loginWithSso on getState to pick up per-test mockResolvedValue settings
     (useAuthStore as any).getState.mockReturnValue({ loginWithSso: mockLoginWithSso });
+    mockSecureGetItemAsync.mockResolvedValue(validPendingState());
   });
 
   it('returns false when the URL has no saml_response param', async () => {
@@ -60,6 +90,48 @@ describe('handleSamlCallbackUrl', () => {
     const result = await handleSamlCallbackUrl('resgrid://auth/callback');
     expect(result).toBe(false);
     expect(mockLoginWithSso).not.toHaveBeenCalled();
+  });
+
+  it('returns false when no pending login state exists', async () => {
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
+    mockSecureGetItemAsync.mockResolvedValue(null);
+    mockGetItem.mockReturnValue('DEPT001');
+
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
+    expect(result).toBe(false);
+    expect(mockLoginWithSso).not.toHaveBeenCalled();
+    expect(mockedLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ message: 'SAML: no pending login state, ignoring deep-link' }));
+  });
+
+  it('returns false when the pending login state is expired', async () => {
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
+    mockSecureGetItemAsync.mockResolvedValue(validPendingState(Date.now() - 11 * 60 * 1000));
+    mockGetItem.mockReturnValue('DEPT001');
+
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
+    expect(result).toBe(false);
+    expect(mockLoginWithSso).not.toHaveBeenCalled();
+    expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
+  });
+
+  it('returns false when the callback state does not match the pending state', async () => {
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml', state: 'attacker-state' } });
+    mockGetItem.mockReturnValue('DEPT001');
+
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml&state=attacker-state');
+    expect(result).toBe(false);
+    expect(mockLoginWithSso).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the pending state is malformed', async () => {
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
+    mockSecureGetItemAsync.mockResolvedValue('not-json');
+    mockGetItem.mockReturnValue('DEPT001');
+
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
+    expect(result).toBe(false);
+    expect(mockLoginWithSso).not.toHaveBeenCalled();
+    expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
   });
 
   it('returns false when no pending department code is stored', async () => {
@@ -76,9 +148,7 @@ describe('handleSamlCallbackUrl', () => {
     mockGetItem.mockReturnValue('DEPT001');
     mockLoginWithSso.mockResolvedValue(undefined);
 
-    const result = await handleSamlCallbackUrl(
-      'resgrid://auth/callback?saml_response=base64saml=',
-    );
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml=');
 
     expect(mockLoginWithSso).toHaveBeenCalledWith({
       provider: 'saml2',
@@ -86,73 +156,157 @@ describe('handleSamlCallbackUrl', () => {
       departmentCode: 'DEPT001',
     });
     expect(mockRemoveItem).toHaveBeenCalledWith(PENDING_SAML_DEPT_CODE_KEY);
+    expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
     expect(result).toBe(true);
   });
 
-  it('returns false and does not clear storage when loginWithSso throws', async () => {
+  it('calls loginWithSso when the callback state matches the pending state', async () => {
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml', state: 'test-state-uuid' } });
+    mockGetItem.mockReturnValue('DEPT001');
+    mockLoginWithSso.mockResolvedValue(undefined);
+
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml&state=test-state-uuid');
+
+    expect(mockLoginWithSso).toHaveBeenCalledWith({
+      provider: 'saml2',
+      externalToken: 'base64saml',
+      departmentCode: 'DEPT001',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false and clears pending state when loginWithSso throws', async () => {
     mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
     mockGetItem.mockReturnValue('DEPT001');
     mockLoginWithSso.mockRejectedValue(new Error('Token exchange failed'));
 
-    const result = await handleSamlCallbackUrl(
-      'resgrid://auth/callback?saml_response=base64saml',
-    );
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
 
     expect(result).toBe(false);
-    expect(mockRemoveItem).not.toHaveBeenCalled();
+    expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
   });
 });
 
-describe('handleSamlCallbackUrl', () => {
+describe('useSamlLogin', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({ loginWithSso: mockLoginWithSso });
+    mockSecureGetItemAsync.mockResolvedValue(validPendingState());
   });
 
-  it('returns false when the URL has no saml_response param', async () => {
-    mockedParse.mockReturnValue({ queryParams: {} });
+  describe('startSamlLogin', () => {
+    it('persists state and department code, then opens the IdP URL with the state param', async () => {
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'https://idp.example.com/sso', departmentCode: 'DEPT001' }));
 
-    const result = await handleSamlCallbackUrl('resgrid://auth/callback');
-    expect(result).toBe(false);
-    expect(mockLoginWithSso).not.toHaveBeenCalled();
-  });
+      await act(async () => {
+        await result.current.startSamlLogin();
+      });
 
-  it('returns false when no pending department code is stored', async () => {
-    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
-    mockGetItem.mockReturnValue(null);
-
-    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
-    expect(result).toBe(false);
-    expect(mockLoginWithSso).not.toHaveBeenCalled();
-  });
-
-  it('calls loginWithSso and clears stored dept code on success', async () => {
-    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml=' } });
-    mockGetItem.mockReturnValue('DEPT001');
-    mockLoginWithSso.mockResolvedValue(undefined);
-
-    const result = await handleSamlCallbackUrl(
-      'resgrid://auth/callback?saml_response=base64saml=',
-    );
-
-    expect(mockLoginWithSso).toHaveBeenCalledWith({
-      provider: 'saml2',
-      externalToken: 'base64saml=',
-      departmentCode: 'DEPT001',
+      expect(mockSecureSetItemAsync).toHaveBeenCalledWith('pending_saml_state', expect.stringContaining('test-state-uuid'));
+      expect(mockSetItem).toHaveBeenCalledWith(PENDING_SAML_DEPT_CODE_KEY, 'DEPT001');
+      expect(mockedOpenBrowserAsync).toHaveBeenCalledWith('https://idp.example.com/sso?state=test-state-uuid');
     });
-    expect(mockRemoveItem).toHaveBeenCalledWith(PENDING_SAML_DEPT_CODE_KEY);
-    expect(result).toBe(true);
+
+    it('appends the state param with & when the URL already has a query string', async () => {
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'https://idp.example.com/sso?foo=bar', departmentCode: 'DEPT001' }));
+
+      await act(async () => {
+        await result.current.startSamlLogin();
+      });
+
+      expect(mockedOpenBrowserAsync).toHaveBeenCalledWith('https://idp.example.com/sso?foo=bar&state=test-state-uuid');
+    });
+
+    it('does nothing when idpSsoUrl is empty', async () => {
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: '', departmentCode: 'DEPT001' }));
+
+      await act(async () => {
+        await result.current.startSamlLogin();
+      });
+
+      expect(mockedOpenBrowserAsync).not.toHaveBeenCalled();
+      expect(mockSecureSetItemAsync).not.toHaveBeenCalled();
+    });
+
+    it('refuses to open a malformed IdP URL', async () => {
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'not a url', departmentCode: 'DEPT001' }));
+
+      await act(async () => {
+        await result.current.startSamlLogin();
+      });
+
+      expect(mockedOpenBrowserAsync).not.toHaveBeenCalled();
+      expect(mockSecureSetItemAsync).not.toHaveBeenCalled();
+      expect(mockedLogger.error).toHaveBeenCalledWith(expect.objectContaining({ message: 'SAML: refusing to open non-HTTPS or malformed IdP SSO URL' }));
+    });
+
+    it('refuses to open an http IdP URL when not in dev mode', async () => {
+      const originalDev = (global as Record<string, unknown>).__DEV__;
+      (global as Record<string, unknown>).__DEV__ = false;
+
+      try {
+        const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'http://idp.example.com/sso', departmentCode: 'DEPT001' }));
+
+        await act(async () => {
+          await result.current.startSamlLogin();
+        });
+
+        expect(mockedOpenBrowserAsync).not.toHaveBeenCalled();
+      } finally {
+        (global as Record<string, unknown>).__DEV__ = originalDev;
+      }
+    });
   });
 
-  it('returns false and does not clear storage when loginWithSso throws', async () => {
-    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
-    mockGetItem.mockReturnValue('DEPT001');
-    mockLoginWithSso.mockRejectedValue(new Error('Token exchange failed'));
+  describe('handleDeepLink', () => {
+    it('returns false when there is no pending login state', async () => {
+      mockSecureGetItemAsync.mockResolvedValue(null);
+      mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
 
-    const result = await handleSamlCallbackUrl(
-      'resgrid://auth/callback?saml_response=base64saml',
-    );
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'https://idp.example.com/sso', departmentCode: 'DEPT001' }));
 
-    expect(result).toBe(false);
-    expect(mockRemoveItem).not.toHaveBeenCalled();
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.handleDeepLink('resgrid://auth/callback?saml_response=base64saml');
+      });
+
+      expect(ok).toBe(false);
+      expect(mockLoginWithSso).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the callback state does not match', async () => {
+      mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml', state: 'wrong-state' } });
+
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'https://idp.example.com/sso', departmentCode: 'DEPT001' }));
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.handleDeepLink('resgrid://auth/callback?saml_response=base64saml&state=wrong-state');
+      });
+
+      expect(ok).toBe(false);
+      expect(mockLoginWithSso).not.toHaveBeenCalled();
+    });
+
+    it('exchanges the response and clears pending state on success', async () => {
+      mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml', state: 'test-state-uuid' } });
+      mockLoginWithSso.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useSamlLogin({ idpSsoUrl: 'https://idp.example.com/sso', departmentCode: 'DEPT001' }));
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.handleDeepLink('resgrid://auth/callback?saml_response=base64saml&state=test-state-uuid');
+      });
+
+      expect(ok).toBe(true);
+      expect(mockLoginWithSso).toHaveBeenCalledWith({
+        provider: 'saml2',
+        externalToken: 'base64saml',
+        departmentCode: 'DEPT001',
+      });
+      expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
+      expect(mockRemoveItem).toHaveBeenCalledWith(PENDING_SAML_DEPT_CODE_KEY);
+    });
   });
 });

--- a/src/hooks/__tests__/use-saml-login.test.ts
+++ b/src/hooks/__tests__/use-saml-login.test.ts
@@ -123,6 +123,17 @@ describe('handleSamlCallbackUrl', () => {
     expect(mockLoginWithSso).not.toHaveBeenCalled();
   });
 
+  it('returns false and clears pending state when the callback state is missing', async () => {
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
+    mockGetItem.mockReturnValue('DEPT001');
+
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
+
+    expect(result).toBe(false);
+    expect(mockLoginWithSso).not.toHaveBeenCalled();
+    expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
+  });
+
   it('returns false when the pending state is malformed', async () => {
     mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
     mockSecureGetItemAsync.mockResolvedValue('not-json');
@@ -135,20 +146,20 @@ describe('handleSamlCallbackUrl', () => {
   });
 
   it('returns false when no pending department code is stored', async () => {
-    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml', state: 'test-state-uuid' } });
     mockGetItem.mockReturnValue(null);
 
-    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml&state=test-state-uuid');
     expect(result).toBe(false);
     expect(mockLoginWithSso).not.toHaveBeenCalled();
   });
 
   it('calls loginWithSso and clears stored dept code on success', async () => {
-    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml=' } });
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml=', state: 'test-state-uuid' } });
     mockGetItem.mockReturnValue('DEPT001');
     mockLoginWithSso.mockResolvedValue(undefined);
 
-    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml=');
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml=&state=test-state-uuid');
 
     expect(mockLoginWithSso).toHaveBeenCalledWith({
       provider: 'saml2',
@@ -176,11 +187,11 @@ describe('handleSamlCallbackUrl', () => {
   });
 
   it('returns false and clears pending state when loginWithSso throws', async () => {
-    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml' } });
+    mockedParse.mockReturnValue({ queryParams: { saml_response: 'base64saml', state: 'test-state-uuid' } });
     mockGetItem.mockReturnValue('DEPT001');
     mockLoginWithSso.mockRejectedValue(new Error('Token exchange failed'));
 
-    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml');
+    const result = await handleSamlCallbackUrl('resgrid://auth/callback?saml_response=base64saml&state=test-state-uuid');
 
     expect(result).toBe(false);
     expect(mockSecureDeleteItemAsync).toHaveBeenCalledWith('pending_saml_state');

--- a/src/hooks/__tests__/use-status-signalr-updates.test.ts
+++ b/src/hooks/__tests__/use-status-signalr-updates.test.ts
@@ -78,7 +78,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify({ UserId: 'different-user' }),
+          lastUpdateMessage: { UserId: 'different-user' },
         });
         return selector(state);
       });
@@ -91,7 +91,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 2000,
-          lastUpdateMessage: JSON.stringify({ UserId: 'user123' }),
+          lastUpdateMessage: { UserId: 'user123' },
         });
         return selector(state);
       });
@@ -113,7 +113,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(personnelStatusMessage),
+          lastUpdateMessage: personnelStatusMessage,
         });
         return selector(state);
       });
@@ -144,7 +144,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(personnelStaffingMessage),
+          lastUpdateMessage: personnelStaffingMessage,
         });
         return selector(state);
       });
@@ -175,7 +175,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(otherUserMessage),
+          lastUpdateMessage: otherUserMessage,
         });
         return selector(state);
       });
@@ -196,7 +196,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: timestamp,
-          lastUpdateMessage: JSON.stringify(personnelStatusMessage),
+          lastUpdateMessage: personnelStatusMessage,
         });
         return selector(state);
       });
@@ -225,7 +225,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: timestamp,
-          lastUpdateMessage: JSON.stringify(personnelStatusMessage),
+          lastUpdateMessage: personnelStatusMessage,
         });
         return selector(state);
       });
@@ -247,7 +247,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: timestamp,
-          lastUpdateMessage: JSON.stringify(newMessage),
+          lastUpdateMessage: newMessage,
         });
         return selector(state);
       });
@@ -273,12 +273,12 @@ describe('useStatusSignalRUpdates', () => {
       const fetchError = new Error('Fetch failed');
       mockFetchCurrentUserInfo.mockRejectedValue(fetchError);
 
-      const validJsonMessage = '{"UserId":"user123","StatusId":1,"StatusText":"Available"}';
+      const validMessage = { UserId: 'user123', StatusId: 1, StatusText: 'Available' };
 
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: validJsonMessage,
+          lastUpdateMessage: validMessage,
         });
         return selector(state);
       });
@@ -299,24 +299,18 @@ describe('useStatusSignalRUpdates', () => {
       });
     });
 
-    it('should handle invalid JSON gracefully', () => {
+    it('should handle string message gracefully', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: 'invalid-json',
+          lastUpdateMessage: 'string-payload',
         });
         return selector(state);
       });
 
       renderHook(() => useStatusSignalRUpdates());
 
-      expect(mockedLogger.error).toHaveBeenCalledWith({
-        message: 'Failed to parse SignalR message',
-        context: { 
-          error: expect.any(SyntaxError), 
-          message: 'invalid-json' 
-        },
-      });
+      expect(mockedLogger.error).not.toHaveBeenCalled();
       expect(mockFetchCurrentUserInfo).not.toHaveBeenCalled();
     });
 
@@ -334,18 +328,20 @@ describe('useStatusSignalRUpdates', () => {
       expect(mockFetchCurrentUserInfo).not.toHaveBeenCalled();
     });
 
-    it('should handle non-string message gracefully', () => {
+    it('should process object message directly without parsing', async () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: { UserId: 'user123' }, // Non-string message
+          lastUpdateMessage: { UserId: 'user123' },
         });
         return selector(state);
       });
 
       renderHook(() => useStatusSignalRUpdates());
 
-      expect(mockFetchCurrentUserInfo).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockFetchCurrentUserInfo).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -359,7 +355,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(messageWithoutUserId),
+          lastUpdateMessage: messageWithoutUserId,
         });
         return selector(state);
       });
@@ -373,7 +369,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify({}),
+          lastUpdateMessage: {},
         });
         return selector(state);
       });
@@ -412,7 +408,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(personnelStatusMessage),
+          lastUpdateMessage: personnelStatusMessage,
         });
         return selector(state);
       });
@@ -443,7 +439,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(personnelStatusMessage),
+          lastUpdateMessage: personnelStatusMessage,
         });
         return selector(state);
       });
@@ -461,7 +457,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 2000,
-          lastUpdateMessage: JSON.stringify(personnelStatusMessage),
+          lastUpdateMessage: personnelStatusMessage,
         });
         return selector(state);
       });
@@ -486,7 +482,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 1000,
-          lastUpdateMessage: JSON.stringify(firstUserMessage),
+          lastUpdateMessage: firstUserMessage,
         });
         return selector(state);
       });
@@ -509,7 +505,7 @@ describe('useStatusSignalRUpdates', () => {
       mockedUseSignalRStore.mockImplementation((selector) => {
         const state = createMockSignalRState({
           lastUpdateTimestamp: 2000,
-          lastUpdateMessage: JSON.stringify(secondUserMessage),
+          lastUpdateMessage: secondUserMessage,
         });
         return selector(state);
       });

--- a/src/hooks/use-map-signalr-updates.ts
+++ b/src/hooks/use-map-signalr-updates.ts
@@ -14,6 +14,7 @@ export const useMapSignalRUpdates = (onMarkersUpdate: (markers: MapMakerInfoData
   const isUpdating = useRef<boolean>(false);
   const pendingTimestamp = useRef<number | null>(null);
   const debounceTimer = useRef<number | null>(null);
+  const queuedFetchTimer = useRef<number | null>(null);
   const abortController = useRef<AbortController | null>(null);
 
   const lastUpdateTimestamp = useSignalRStore((state) => state.lastUpdateTimestamp);
@@ -126,7 +127,10 @@ export const useMapSignalRUpdates = (onMarkersUpdate: (markers: MapMakerInfoData
             context: { nextTimestamp },
           });
           // Use setTimeout to avoid potential stack overflow in case of rapid updates
-          setTimeout(() => fetchAndUpdateMarkers(nextTimestamp), 0);
+          queuedFetchTimer.current = setTimeout(() => {
+            queuedFetchTimer.current = null;
+            fetchAndUpdateMarkers(nextTimestamp);
+          }, 0);
         }
       }
     },
@@ -171,6 +175,12 @@ export const useMapSignalRUpdates = (onMarkersUpdate: (markers: MapMakerInfoData
       // Clear debounce timer
       if (debounceTimer.current) {
         clearTimeout(debounceTimer.current);
+      }
+
+      // Clear any queued follow-up fetch
+      if (queuedFetchTimer.current) {
+        clearTimeout(queuedFetchTimer.current);
+        queuedFetchTimer.current = null;
       }
 
       // Abort any ongoing request

--- a/src/hooks/use-oidc-login.ts
+++ b/src/hooks/use-oidc-login.ts
@@ -14,6 +14,22 @@ export interface UseOidcLoginOptions {
   departmentCode: string;
 }
 
+export const isValidSsoUrl = (url: string): boolean => {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'https:') {
+      return true;
+    }
+    return __DEV__ && parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+};
+
 export interface UseOidcLoginResult {
   request: AuthSession.AuthRequest | null;
   response: AuthSession.AuthSessionResult | null;
@@ -32,9 +48,11 @@ export interface UseOidcLoginResult {
 export function useOidcLogin({ authority, clientId, departmentCode }: UseOidcLoginOptions): UseOidcLoginResult {
   const redirectUri = AuthSession.makeRedirectUri({ scheme: 'resgrid', path: 'auth/callback' });
 
+  const safeAuthority = isValidSsoUrl(authority) ? authority : '';
+
   // Auto-discover OIDC endpoints from the authority's /.well-known/openid-configuration
   // discovery will be null until the authority URL is non-empty and valid
-  const discovery = AuthSession.useAutoDiscovery(authority || '');
+  const discovery = AuthSession.useAutoDiscovery(safeAuthority);
 
   const [request, response, promptAsync] = AuthSession.useAuthRequest(
     {
@@ -45,7 +63,7 @@ export function useOidcLogin({ authority, clientId, departmentCode }: UseOidcLog
       responseType: AuthSession.ResponseType.Code,
     },
     // Pass null discovery when authority is not yet set to prevent premature requests
-    authority ? discovery : null
+    safeAuthority ? discovery : null
   );
 
   const { loginWithSso } = useAuthStore();

--- a/src/hooks/use-saml-login.ts
+++ b/src/hooks/use-saml-login.ts
@@ -1,13 +1,86 @@
+import * as Crypto from 'expo-crypto';
 import * as Linking from 'expo-linking';
+import * as SecureStore from 'expo-secure-store';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback } from 'react';
 
+import { isValidSsoUrl } from '@/hooks/use-oidc-login';
 import { logger } from '@/lib/logging';
 import { getItem, removeItem, setItem } from '@/lib/storage';
-import useAuthStore from '@/stores/auth/store';
+import useAuthStore, { PENDING_SAML_STATE_KEY } from '@/stores/auth/store';
 
 /** MMKV key used to persist the active SAML department code across cold starts */
 export const PENDING_SAML_DEPT_CODE_KEY = 'pending_saml_dept_code';
+
+const PENDING_SAML_STATE_TTL_MS = 10 * 60 * 1000;
+
+interface PendingSamlState {
+  state: string;
+  createdAt: number;
+}
+
+export async function clearPendingSamlState(): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(PENDING_SAML_STATE_KEY);
+  } catch (error) {
+    logger.warn({
+      message: 'SAML: failed to clear pending state',
+      context: { error: error instanceof Error ? error.message : String(error) },
+    });
+  }
+}
+
+const savePendingSamlState = async (state: string): Promise<void> => {
+  const payload: PendingSamlState = { state, createdAt: Date.now() };
+  await SecureStore.setItemAsync(PENDING_SAML_STATE_KEY, JSON.stringify(payload));
+};
+
+const consumePendingSamlState = async (callbackState?: string): Promise<boolean> => {
+  let raw: string | null = null;
+  try {
+    raw = await SecureStore.getItemAsync(PENDING_SAML_STATE_KEY);
+  } catch (error) {
+    logger.error({
+      message: 'SAML: failed to read pending state',
+      context: { error: error instanceof Error ? error.message : String(error) },
+    });
+    return false;
+  }
+
+  if (!raw) {
+    logger.warn({ message: 'SAML: no pending login state, ignoring deep-link' });
+    return false;
+  }
+
+  let pending: PendingSamlState;
+  try {
+    pending = JSON.parse(raw) as PendingSamlState;
+  } catch {
+    logger.warn({ message: 'SAML: pending login state is malformed, clearing' });
+    await clearPendingSamlState();
+    return false;
+  }
+
+  if (!pending.state || typeof pending.createdAt !== 'number') {
+    logger.warn({ message: 'SAML: pending login state is malformed, clearing' });
+    await clearPendingSamlState();
+    return false;
+  }
+
+  if (Date.now() - pending.createdAt > PENDING_SAML_STATE_TTL_MS) {
+    logger.warn({ message: 'SAML: pending login state expired, ignoring deep-link' });
+    await clearPendingSamlState();
+    return false;
+  }
+
+  if (callbackState && callbackState !== pending.state) {
+    logger.warn({ message: 'SAML: callback state mismatch, ignoring deep-link' });
+    await clearPendingSamlState();
+    return false;
+  }
+
+  return true;
+};
 
 export interface UseSamlLoginOptions {
   idpSsoUrl: string;
@@ -42,11 +115,21 @@ export function useSamlLogin({ idpSsoUrl, departmentCode }: UseSamlLoginOptions)
       return;
     }
 
+    if (!isValidSsoUrl(idpSsoUrl)) {
+      logger.error({ message: 'SAML: refusing to open non-HTTPS or malformed IdP SSO URL', context: { idpSsoUrl } });
+      return;
+    }
+
+    const state = Crypto.randomUUID();
+    await savePendingSamlState(state);
+
     // Persist department code so the cold-start deep-link handler can retrieve it
     await setItem<string>(PENDING_SAML_DEPT_CODE_KEY, departmentCode);
 
+    const initiateUrl = `${idpSsoUrl}${idpSsoUrl.includes('?') ? '&' : '?'}state=${encodeURIComponent(state)}`;
+
     logger.info({ message: 'SAML: opening IdP SSO URL', context: { idpSsoUrl } });
-    await WebBrowser.openBrowserAsync(idpSsoUrl);
+    await WebBrowser.openBrowserAsync(initiateUrl);
   }, [idpSsoUrl, departmentCode]);
 
   const handleDeepLink = useCallback(
@@ -59,6 +142,12 @@ export function useSamlLogin({ idpSsoUrl, departmentCode }: UseSamlLoginOptions)
         return false;
       }
 
+      const stateValid = await consumePendingSamlState(parsed.queryParams?.state as string | undefined);
+      if (!stateValid) {
+        await removeItem(PENDING_SAML_DEPT_CODE_KEY);
+        return false;
+      }
+
       logger.info({ message: 'SAML: received saml_response via deep-link, exchanging for Resgrid token' });
 
       try {
@@ -67,15 +156,16 @@ export function useSamlLogin({ idpSsoUrl, departmentCode }: UseSamlLoginOptions)
           externalToken: samlResponse,
           departmentCode,
         });
-        await removeItem(PENDING_SAML_DEPT_CODE_KEY);
         return true;
       } catch (error) {
-        await removeItem(PENDING_SAML_DEPT_CODE_KEY);
         logger.error({
           message: 'SAML: token exchange failed',
           context: { error: error instanceof Error ? error.message : String(error) },
         });
         return false;
+      } finally {
+        await clearPendingSamlState();
+        await removeItem(PENDING_SAML_DEPT_CODE_KEY);
       }
     },
     [departmentCode, loginWithSso]
@@ -95,9 +185,16 @@ export async function handleSamlCallbackUrl(url: string): Promise<boolean> {
 
   if (!samlResponse) return false;
 
+  const stateValid = await consumePendingSamlState(parsed.queryParams?.state as string | undefined);
+  if (!stateValid) {
+    await removeItem(PENDING_SAML_DEPT_CODE_KEY);
+    return false;
+  }
+
   const departmentCode = getItem<string>(PENDING_SAML_DEPT_CODE_KEY);
   if (!departmentCode) {
     logger.warn({ message: 'SAML cold-start: no pending department code found in storage' });
+    await clearPendingSamlState();
     return false;
   }
 
@@ -117,5 +214,7 @@ export async function handleSamlCallbackUrl(url: string): Promise<boolean> {
       context: { error: error instanceof Error ? error.message : String(error) },
     });
     return false;
+  } finally {
+    await clearPendingSamlState();
   }
 }

--- a/src/hooks/use-saml-login.ts
+++ b/src/hooks/use-saml-login.ts
@@ -73,8 +73,8 @@ const consumePendingSamlState = async (callbackState?: string): Promise<boolean>
     return false;
   }
 
-  if (callbackState && callbackState !== pending.state) {
-    logger.warn({ message: 'SAML: callback state mismatch, ignoring deep-link' });
+  if (!callbackState || callbackState !== pending.state) {
+    logger.warn({ message: 'SAML: callback state missing or mismatched, ignoring deep-link' });
     await clearPendingSamlState();
     return false;
   }

--- a/src/hooks/use-signalr-lifecycle.ts
+++ b/src/hooks/use-signalr-lifecycle.ts
@@ -12,7 +12,10 @@ interface UseSignalRLifecycleOptions {
 
 export function useSignalRLifecycle({ isSignedIn, hasInitialized }: UseSignalRLifecycleOptions) {
   const { isActive, appState } = useAppLifecycle();
-  const signalRStore = useSignalRStore();
+  const connectUpdateHub = useSignalRStore((state) => state.connectUpdateHub);
+  const disconnectUpdateHub = useSignalRStore((state) => state.disconnectUpdateHub);
+  const connectGeolocationHub = useSignalRStore((state) => state.connectGeolocationHub);
+  const disconnectGeolocationHub = useSignalRStore((state) => state.disconnectGeolocationHub);
 
   // Track current values with refs for timer callbacks
   const currentIsActive = useRef(isActive);
@@ -63,7 +66,7 @@ export function useSignalRLifecycle({ isSignedIn, hasInitialized }: UseSignalRLi
 
     try {
       // Use Promise.allSettled to prevent one failure from blocking the other
-      const results = await Promise.allSettled([signalRStore.disconnectUpdateHub(), signalRStore.disconnectGeolocationHub()]);
+      const results = await Promise.allSettled([disconnectUpdateHub(), disconnectGeolocationHub()]);
 
       // Log any failures without throwing
       results.forEach((result, index) => {
@@ -86,7 +89,7 @@ export function useSignalRLifecycle({ isSignedIn, hasInitialized }: UseSignalRLi
         pendingOperations.current = null;
       }
     }
-  }, [signalRStore]);
+  }, [disconnectUpdateHub, disconnectGeolocationHub]);
 
   const handleAppResume = useCallback(async () => {
     logger.debug({
@@ -117,7 +120,7 @@ export function useSignalRLifecycle({ isSignedIn, hasInitialized }: UseSignalRLi
 
     try {
       // Use Promise.allSettled to prevent one failure from blocking the other
-      const results = await Promise.allSettled([signalRStore.connectUpdateHub(), signalRStore.connectGeolocationHub()]);
+      const results = await Promise.allSettled([connectUpdateHub(), connectGeolocationHub()]);
 
       // Log any failures without throwing
       results.forEach((result, index) => {
@@ -140,7 +143,7 @@ export function useSignalRLifecycle({ isSignedIn, hasInitialized }: UseSignalRLi
         pendingOperations.current = null;
       }
     }
-  }, [signalRStore]);
+  }, [connectUpdateHub, connectGeolocationHub]);
 
   // Clear timers helper
   const clearTimers = useCallback(() => {

--- a/src/hooks/use-status-signalr-updates.ts
+++ b/src/hooks/use-status-signalr-updates.ts
@@ -23,33 +23,25 @@ export const useStatusSignalRUpdates = () => {
           return;
         }
 
-        // Parse the SignalR message to check if it's a personnel status/staffing update
-        if (lastUpdateMessage && typeof lastUpdateMessage === 'string') {
-          try {
-            const parsedMessage = JSON.parse(lastUpdateMessage);
+        // Check if this is a personnel status or staffing update message for the current user
+        if (lastUpdateMessage && typeof lastUpdateMessage === 'object') {
+          const parsedMessage = lastUpdateMessage as { UserId?: string };
 
-            // Check if this is a personnel status or staffing update message for the current user
-            if (parsedMessage && parsedMessage.UserId === userId) {
-              logger.info({
-                message: 'Processing personnel status/staffing update for current user',
-                context: {
-                  userId,
-                  timestamp: lastUpdateTimestamp,
-                  message: parsedMessage,
-                },
-              });
-
-              // Refresh the current user's status and staffing
-              await fetchCurrentUserInfo();
-
-              // Update the last processed timestamp
-              lastProcessedTimestamp.current = lastUpdateTimestamp;
-            }
-          } catch (parseError) {
-            logger.error({
-              message: 'Failed to parse SignalR message',
-              context: { error: parseError, message: lastUpdateMessage },
+          if (parsedMessage.UserId === userId) {
+            logger.info({
+              message: 'Processing personnel status/staffing update for current user',
+              context: {
+                userId,
+                timestamp: lastUpdateTimestamp,
+                message: parsedMessage,
+              },
             });
+
+            // Refresh the current user's status and staffing
+            await fetchCurrentUserInfo();
+
+            // Update the last processed timestamp
+            lastProcessedTimestamp.current = lastUpdateTimestamp;
           }
         }
       } catch (error) {

--- a/src/hooks/useSignalR.ts
+++ b/src/hooks/useSignalR.ts
@@ -1,30 +1,38 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { logger } from '@/lib/logging';
 import { type SignalRHubConfig, signalRService } from '@/services/signalr.service';
 
 export const useSignalR = (config: SignalRHubConfig) => {
+  const configRef = useRef(config);
+
+  useEffect(() => {
+    configRef.current = config;
+  });
+
+  const hubName = config.name;
+
   const connect = useCallback(async () => {
     try {
-      await signalRService.connectToHub(config);
+      await signalRService.connectToHub(configRef.current);
     } catch (error) {
       logger.error({
         message: 'Failed to connect to SignalR hub',
-        context: { error, config },
+        context: { error, config: configRef.current },
       });
     }
-  }, [config]);
+  }, []);
 
   const disconnect = useCallback(async () => {
     try {
-      await signalRService.disconnectFromHub(config.name);
+      await signalRService.disconnectFromHub(hubName);
     } catch (error) {
       logger.error({
         message: 'Failed to disconnect from SignalR hub',
-        context: { error, config },
+        context: { error, config: configRef.current },
       });
     }
-  }, [config]);
+  }, [hubName]);
 
   useEffect(() => {
     connect();

--- a/src/lib/cache/__tests__/cache-manager.test.ts
+++ b/src/lib/cache/__tests__/cache-manager.test.ts
@@ -1,0 +1,70 @@
+jest.mock('@/lib/storage', () => ({
+  storage: {
+    getString: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+    getAllKeys: jest.fn(() => []),
+  },
+}));
+
+jest.mock('@/lib/logging', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const { cacheManager } = require('@/lib/cache/cache-manager');
+const { storage } = require('@/lib/storage');
+
+describe('CacheManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null and delete the key on corrupt cache entry', () => {
+    storage.getString.mockReturnValue('{not-valid-json');
+
+    const result = cacheManager.get('/endpoint');
+
+    expect(result).toBeNull();
+    expect(storage.delete).toHaveBeenCalledWith('api_cache_/endpoint');
+  });
+
+  it('should return cached data for a valid unexpired entry', () => {
+    storage.getString.mockReturnValue(
+      JSON.stringify({
+        data: { foo: 'bar' },
+        timestamp: Date.now(),
+        expiresIn: 60000,
+      })
+    );
+
+    const result = cacheManager.get('/endpoint');
+
+    expect(result).toEqual({ foo: 'bar' });
+  });
+
+  it('should return null and delete the key on expired entry', () => {
+    storage.getString.mockReturnValue(
+      JSON.stringify({
+        data: { foo: 'bar' },
+        timestamp: Date.now() - 120000,
+        expiresIn: 60000,
+      })
+    );
+
+    const result = cacheManager.get('/endpoint');
+
+    expect(result).toBeNull();
+    expect(storage.delete).toHaveBeenCalledWith('api_cache_/endpoint');
+  });
+
+  it('should return null when no cache entry exists', () => {
+    storage.getString.mockReturnValue(undefined);
+
+    expect(cacheManager.get('/endpoint')).toBeNull();
+  });
+});

--- a/src/lib/cache/__tests__/cache-manager.test.ts
+++ b/src/lib/cache/__tests__/cache-manager.test.ts
@@ -17,6 +17,7 @@ jest.mock('@/lib/logging', () => ({
 }));
 
 const { cacheManager } = require('@/lib/cache/cache-manager');
+const { logger } = require('@/lib/logging');
 const { storage } = require('@/lib/storage');
 
 describe('CacheManager', () => {
@@ -30,6 +31,25 @@ describe('CacheManager', () => {
     const result = cacheManager.get('/endpoint');
 
     expect(result).toBeNull();
+    expect(storage.delete).toHaveBeenCalledWith('api_cache_/endpoint');
+  });
+
+  it.each([
+    ['null', null],
+    ['an array', []],
+    ['missing data', { timestamp: Date.now(), expiresIn: 60000 }],
+    ['an invalid timestamp', { data: { foo: 'bar' }, timestamp: -1, expiresIn: 60000 }],
+    ['an invalid expiration', { data: { foo: 'bar' }, timestamp: Date.now(), expiresIn: Number.POSITIVE_INFINITY }],
+  ])('should remove a parsed cache entry with %s', (_description, cacheItem) => {
+    storage.getString.mockReturnValue(JSON.stringify(cacheItem));
+
+    const result = cacheManager.get('/endpoint');
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: 'Corrupt cache entry, removing',
+      context: { key: 'api_cache_/endpoint', error: 'Invalid cache item shape' },
+    });
     expect(storage.delete).toHaveBeenCalledWith('api_cache_/endpoint');
   });
 

--- a/src/lib/cache/cache-manager.ts
+++ b/src/lib/cache/cache-manager.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logging';
 import { storage } from '@/lib/storage';
 
 interface CacheItem<T> {
@@ -46,7 +47,17 @@ export class CacheManager {
       return null;
     }
 
-    const cacheItem: CacheItem<T> = JSON.parse(cached);
+    let cacheItem: CacheItem<T>;
+    try {
+      cacheItem = JSON.parse(cached);
+    } catch (error) {
+      logger.warn({
+        message: 'Corrupt cache entry, removing',
+        context: { key, error },
+      });
+      storage.delete(key);
+      return null;
+    }
 
     if (this.isExpired(cacheItem.timestamp, cacheItem.expiresIn)) {
       storage.delete(key);

--- a/src/lib/cache/cache-manager.ts
+++ b/src/lib/cache/cache-manager.ts
@@ -7,6 +7,23 @@ interface CacheItem<T> {
   expiresIn: number;
 }
 
+const isCacheItem = <T>(value: unknown): value is CacheItem<T> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const item = value as Partial<CacheItem<T>>;
+  return (
+    Object.prototype.hasOwnProperty.call(item, 'data') &&
+    typeof item.timestamp === 'number' &&
+    Number.isFinite(item.timestamp) &&
+    item.timestamp >= 0 &&
+    typeof item.expiresIn === 'number' &&
+    Number.isFinite(item.expiresIn) &&
+    item.expiresIn >= 0
+  );
+};
+
 export class CacheManager {
   private static instance: CacheManager;
   private defaultTTL = 5 * 60 * 1000; // 5 minutes default
@@ -47,9 +64,9 @@ export class CacheManager {
       return null;
     }
 
-    let cacheItem: CacheItem<T>;
+    let parsed: unknown;
     try {
-      cacheItem = JSON.parse(cached);
+      parsed = JSON.parse(cached);
     } catch (error) {
       logger.warn({
         message: 'Corrupt cache entry, removing',
@@ -59,6 +76,16 @@ export class CacheManager {
       return null;
     }
 
+    if (!isCacheItem<T>(parsed)) {
+      logger.warn({
+        message: 'Corrupt cache entry, removing',
+        context: { key, error: 'Invalid cache item shape' },
+      });
+      storage.delete(key);
+      return null;
+    }
+
+    const cacheItem = parsed;
     if (this.isExpired(cacheItem.timestamp, cacheItem.expiresIn)) {
       storage.delete(key);
       return null;

--- a/src/lib/hooks/__tests__/use-realtime-geolocation.test.ts
+++ b/src/lib/hooks/__tests__/use-realtime-geolocation.test.ts
@@ -50,11 +50,13 @@ describe('useRealtimeGeolocation', () => {
     mockDisconnectGeolocationHub = jest.fn();
 
     mockUseMMKVBoolean.mockReturnValue([false, mockSetRealtimeGeolocationEnabled]);
-    mockUseSignalRStore.mockReturnValue({
-      isGeolocationHubConnected: false,
-      connectGeolocationHub: mockConnectGeolocationHub,
-      disconnectGeolocationHub: mockDisconnectGeolocationHub,
-    });
+    mockUseSignalRStore.mockImplementation((selector: any) =>
+      selector({
+        isGeolocationHubConnected: false,
+        connectGeolocationHub: mockConnectGeolocationHub,
+        disconnectGeolocationHub: mockDisconnectGeolocationHub,
+      })
+    );
   });
 
   it('should return initial state', () => {
@@ -148,11 +150,13 @@ describe('useRealtimeGeolocation', () => {
   });
 
   it('should return hub connected state', () => {
-    mockUseSignalRStore.mockReturnValue({
-      isGeolocationHubConnected: true,
-      connectGeolocationHub: mockConnectGeolocationHub,
-      disconnectGeolocationHub: mockDisconnectGeolocationHub,
-    });
+    mockUseSignalRStore.mockImplementation((selector: any) =>
+      selector({
+        isGeolocationHubConnected: true,
+        connectGeolocationHub: mockConnectGeolocationHub,
+        disconnectGeolocationHub: mockDisconnectGeolocationHub,
+      })
+    );
 
     const { result } = renderHook(() => useRealtimeGeolocation());
 

--- a/src/lib/hooks/use-realtime-geolocation.ts
+++ b/src/lib/hooks/use-realtime-geolocation.ts
@@ -30,7 +30,9 @@ export const registerLocationServiceRealtimeUpdater = (updater: LocationServiceR
 export const useRealtimeGeolocation = () => {
   const [realtimeGeolocationEnabled, _setRealtimeGeolocationEnabled] = useMMKVBoolean(getRealtimeGeolocationStorageKey(), storage);
 
-  const { isGeolocationHubConnected, connectGeolocationHub, disconnectGeolocationHub } = useSignalRStore();
+  const isGeolocationHubConnected = useSignalRStore((state) => state.isGeolocationHubConnected);
+  const connectGeolocationHub = useSignalRStore((state) => state.connectGeolocationHub);
+  const disconnectGeolocationHub = useSignalRStore((state) => state.disconnectGeolocationHub);
 
   const setRealtimeGeolocationEnabled = React.useCallback(
     async (enabled: boolean) => {

--- a/src/lib/storage/secure-storage.ts
+++ b/src/lib/storage/secure-storage.ts
@@ -162,80 +162,86 @@ class WebEncryptedStorage {
 let generalStorage: MMKV | undefined;
 let offlineQueueStorage: MMKV | undefined;
 let webEncryptedStorage: WebEncryptedStorage | undefined;
-let storageInitializing = false;
+let initPromise: Promise<void> | null = null;
 
-const initializeStorage = async (): Promise<void> => {
-  if (storageInitializing) return;
-  storageInitializing = true;
-  try {
-    if (Platform.OS === 'web') {
-      // For web, use encrypted localStorage
-      const encryptionKey = Env.STORAGE_ENCRYPTION_KEY || generateSecureKey();
-      webEncryptedStorage = new WebEncryptedStorage(encryptionKey);
+const initializeStorage = (): Promise<void> => {
+  // Single-flight: share one in-flight init promise across all concurrent callers
+  if (initPromise) return initPromise;
 
-      // Create a MMKV instance that uses our encrypted web storage
+  initPromise = (async (): Promise<void> => {
+    try {
+      if (Platform.OS === 'web') {
+        // For web, use encrypted localStorage
+        const encryptionKey = Env.STORAGE_ENCRYPTION_KEY || generateSecureKey();
+        webEncryptedStorage = new WebEncryptedStorage(encryptionKey);
+
+        // Create a MMKV instance that uses our encrypted web storage
+        generalStorage = new MMKV({
+          id: 'ResgridUnit',
+        });
+
+        // For offline queue, we'll disable persistence on web for PII safety
+        offlineQueueStorage = new MMKV({
+          id: 'ResgridOfflineQueue',
+        });
+
+        logger.info({
+          message: 'Initialized web storage with encryption',
+        });
+      } else {
+        // For mobile platforms, use secure key storage
+        const generalKey = await getOrCreateSecureKey(ENCRYPTION_KEY_STORAGE_KEY);
+        const offlineQueueKey = await getOrCreateSecureKey(OFFLINE_QUEUE_KEY_STORAGE_KEY);
+
+        generalStorage = new MMKV({
+          id: 'ResgridUnit',
+          encryptionKey: generalKey,
+        });
+
+        offlineQueueStorage = new MMKV({
+          id: 'ResgridOfflineQueue',
+          encryptionKey: offlineQueueKey,
+        });
+
+        logger.info({
+          message: 'Initialized mobile storage with secure encryption keys',
+        });
+      }
+    } catch (error) {
+      logger.error({
+        message: 'Failed to initialize secure storage, falling back to basic storage',
+        context: { error },
+      });
+
+      // Fallback to basic MMKV without encryption
       generalStorage = new MMKV({
         id: 'ResgridUnit',
       });
 
-      // For offline queue, we'll disable persistence on web for PII safety
       offlineQueueStorage = new MMKV({
         id: 'ResgridOfflineQueue',
-      });
-
-      logger.info({
-        message: 'Initialized web storage with encryption',
-      });
-    } else {
-      // For mobile platforms, use secure key storage
-      const generalKey = await getOrCreateSecureKey(ENCRYPTION_KEY_STORAGE_KEY);
-      const offlineQueueKey = await getOrCreateSecureKey(OFFLINE_QUEUE_KEY_STORAGE_KEY);
-
-      generalStorage = new MMKV({
-        id: 'ResgridUnit',
-        encryptionKey: generalKey,
-      });
-
-      offlineQueueStorage = new MMKV({
-        id: 'ResgridOfflineQueue',
-        encryptionKey: offlineQueueKey,
-      });
-
-      logger.info({
-        message: 'Initialized mobile storage with secure encryption keys',
       });
     }
-  } catch (error) {
-    logger.error({
-      message: 'Failed to initialize secure storage, falling back to basic storage',
-      context: { error },
-    });
+  })();
 
-    // Fallback to basic MMKV without encryption
-    generalStorage = new MMKV({
-      id: 'ResgridUnit',
-    });
-
-    offlineQueueStorage = new MMKV({
-      id: 'ResgridOfflineQueue',
-    });
-    storageInitializing = false;
-  }
+  return initPromise;
 };
 
 // Storage getters with lazy initialization
 export const getGeneralStorage = async (): Promise<MMKV> => {
+  await initializeStorage();
   if (!generalStorage) {
-    await initializeStorage();
+    throw new Error('General storage failed to initialize');
   }
-  return generalStorage!;
+  return generalStorage;
 };
 
 export const getOfflineQueueStorage = async (): Promise<MMKV> => {
+  await initializeStorage();
   if (!offlineQueueStorage) {
-    await initializeStorage();
+    throw new Error('Offline queue storage failed to initialize');
   }
-  return offlineQueueStorage!;
+  return offlineQueueStorage;
 };
 
 export const getWebEncryptedStorage = (): WebEncryptedStorage | undefined => {

--- a/src/services/__tests__/location.test.ts
+++ b/src/services/__tests__/location.test.ts
@@ -308,6 +308,20 @@ describe('LocationService', () => {
       });
     });
 
+    it('should remove existing foreground subscription before starting a new one (idempotent restarts)', async () => {
+      await locationService.startLocationUpdates();
+      const firstSubscription = mockLocationSubscription;
+
+      const secondSubscription = { remove: jest.fn() };
+      mockLocation.watchPositionAsync.mockResolvedValue(secondSubscription as jest.Mocked<Location.LocationSubscription>);
+
+      await locationService.startLocationUpdates();
+
+      expect(firstSubscription.remove).toHaveBeenCalledTimes(1);
+      expect(mockLocation.watchPositionAsync).toHaveBeenCalledTimes(2);
+      expect((locationService as any).locationSubscription).toBe(secondSubscription);
+    });
+
     it('should throw error if permissions are not granted', async () => {
       mockLocation.requestForegroundPermissionsAsync.mockResolvedValue({
         status: 'denied' as any,

--- a/src/services/__tests__/location.test.ts
+++ b/src/services/__tests__/location.test.ts
@@ -917,6 +917,10 @@ describe('LocationService', () => {
       mockLocation.watchPositionAsync.mockRejectedValue(error);
 
       await expect(locationService.startLocationUpdates()).rejects.toThrow('Location subscription failed');
+      expect(mockLogger.error).toHaveBeenCalledWith({
+        message: 'Failed to start location updates',
+        context: { error },
+      });
     });
 
     it('should handle background task registration errors', async () => {

--- a/src/services/__tests__/location.test.ts
+++ b/src/services/__tests__/location.test.ts
@@ -219,6 +219,7 @@ describe('LocationService', () => {
 
     // Reset internal state of the service
     (locationService as any).locationSubscription = null;
+    (locationService as any).startLocationUpdatesPromise = null;
     (locationService as any).backgroundSubscription = null;
     (locationService as any).isBackgroundGeolocationEnabled = false;
     (locationService as any).isRealtimeGeolocationEnabled = false;
@@ -320,6 +321,25 @@ describe('LocationService', () => {
       expect(firstSubscription.remove).toHaveBeenCalledTimes(1);
       expect(mockLocation.watchPositionAsync).toHaveBeenCalledTimes(2);
       expect((locationService as any).locationSubscription).toBe(secondSubscription);
+    });
+
+    it('should create only one watcher when location starts overlap', async () => {
+      let resolveWatcher: (subscription: Location.LocationSubscription) => void;
+      const watcherPromise = new Promise<Location.LocationSubscription>((resolve) => {
+        resolveWatcher = resolve;
+      });
+      mockLocation.watchPositionAsync.mockReturnValue(watcherPromise);
+
+      const firstStart = locationService.startLocationUpdates();
+      const secondStart = locationService.startLocationUpdates();
+
+      expect(firstStart).toBe(secondStart);
+
+      resolveWatcher!(mockLocationSubscription);
+      await Promise.all([firstStart, secondStart]);
+
+      expect(mockLocation.watchPositionAsync).toHaveBeenCalledTimes(1);
+      expect((locationService as any).locationSubscription).toBe(mockLocationSubscription);
     });
 
     it('should throw error if permissions are not granted', async () => {

--- a/src/services/__tests__/offline-queue-processor.test.ts
+++ b/src/services/__tests__/offline-queue-processor.test.ts
@@ -3,6 +3,16 @@
 // Mock NetInfo to prevent native dependencies
 jest.mock('@react-native-community/netinfo', () => ({ addEventListener: jest.fn() }));
 
+// Mock logger
+jest.mock('@/lib/logging', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
 // Mock secure storage to stub storage operations
 jest.mock('@/lib/storage/secure-storage', () => ({
   getOfflineQueueStorage: jest.fn().mockResolvedValue({
@@ -19,15 +29,39 @@ jest.mock('@/api/personnel/personnelStatuses', () => ({
 // Require modules after mocks are set up
 const { offlineQueueProcessor, OfflineQueueProcessor } = require('@/services/offline-queue-processor');
 const { SavePersonStatusInput } = require('@/models/v4/personnelStatuses/savePersonStatusInput');
+const { logger } = require('@/lib/logging');
 
 describe('offlineQueueProcessor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be an instance of OfflineQueueProcessor', () => {
     expect(offlineQueueProcessor).toBeInstanceOf(OfflineQueueProcessor);
   });
 
   it('should return empty string for addPersonnelStatusToQueue', () => {
-  const input = new SavePersonStatusInput();
-  const result = offlineQueueProcessor.addPersonnelStatusToQueue(input);
+    const input = new SavePersonStatusInput();
+    const result = offlineQueueProcessor.addPersonnelStatusToQueue(input);
     expect(result).toBe('');
+  });
+
+  it('should log a warning when the stub discards an enqueued item', () => {
+    const input = new SavePersonStatusInput();
+    offlineQueueProcessor.addPersonnelStatusToQueue(input);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('Stub offline queue'),
+      })
+    );
+  });
+
+  it('should log a warning when the stub processes the queue', async () => {
+    await offlineQueueProcessor.processQueue();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('Stub offline queue'),
+      })
+    );
   });
 });

--- a/src/services/__tests__/offline-queue-processor.test.ts
+++ b/src/services/__tests__/offline-queue-processor.test.ts
@@ -27,7 +27,9 @@ jest.mock('@/api/personnel/personnelStatuses', () => ({
 }));
 
 // Require modules after mocks are set up
-const { offlineQueueProcessor, OfflineQueueProcessor } = require('@/services/offline-queue-processor');
+const { offlineQueueProcessor, OfflineQueueProcessor, RealOfflineQueueProcessor } = require('@/services/offline-queue-processor');
+const { savePersonnelStatus } = require('@/api/personnel/personnelStatuses');
+const { getOfflineQueueStorage } = require('@/lib/storage/secure-storage');
 const { SavePersonStatusInput } = require('@/models/v4/personnelStatuses/savePersonStatusInput');
 const { logger } = require('@/lib/logging');
 
@@ -48,12 +50,25 @@ describe('offlineQueueProcessor', () => {
 
   it('should log a warning when the stub discards an enqueued item', () => {
     const input = new SavePersonStatusInput();
+    input.UserId = 'user-1';
+    input.EventId = 'event-1';
+    input.Note = 'sensitive note';
     offlineQueueProcessor.addPersonnelStatusToQueue(input);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('Stub offline queue'),
+        context: {
+          userIdHash: expect.any(String),
+          eventIdHash: expect.any(String),
+          lawful_basis: 'legitimate_interests',
+          purpose: 'offline_queue_diagnostics',
+        },
       })
     );
+    const context = logger.warn.mock.calls[0][0].context;
+    expect(context).not.toHaveProperty('status');
+    expect(context.userIdHash).not.toBe(input.UserId);
+    expect(context.eventIdHash).not.toBe(input.EventId);
   });
 
   it('should log a warning when the stub processes the queue', async () => {
@@ -63,5 +78,128 @@ describe('offlineQueueProcessor', () => {
         message: expect.stringContaining('Stub offline queue'),
       })
     );
+  });
+});
+
+describe('RealOfflineQueueProcessor', () => {
+  const processor = RealOfflineQueueProcessor.getInstance();
+  let storage: { getString: jest.Mock; set: jest.Mock };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    storage = await getOfflineQueueStorage();
+    storage.getString.mockReturnValue('[]');
+    storage.set.mockResolvedValue(undefined);
+    savePersonnelStatus.mockResolvedValue(undefined);
+    processor.processing = false;
+    processor.queueMutationChain = Promise.resolve();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('schedules and persists a failed item without sleeping', async () => {
+    const now = 100000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    storage.getString.mockReturnValue(
+      JSON.stringify([
+        {
+          id: 'item-1',
+          type: 'personnelStatus',
+          payload: { UserId: 'user-1' },
+          retries: 0,
+          attempts: 0,
+        },
+      ])
+    );
+    savePersonnelStatus.mockRejectedValue(new Error('offline'));
+
+    await processor.processQueue();
+
+    const persisted = JSON.parse(storage.set.mock.calls[0][1]);
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        id: 'item-1',
+        retries: 1,
+        attempts: 1,
+        nextRetryAt: now + 2000,
+      }),
+    ]);
+  });
+
+  it('processes only items whose next retry time has elapsed', async () => {
+    const now = 100000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const futureItem = {
+      id: 'future',
+      type: 'personnelStatus',
+      payload: { UserId: 'future-user' },
+      retries: 1,
+      attempts: 1,
+      nextRetryAt: now + 1000,
+    };
+    const dueItem = {
+      id: 'due',
+      type: 'personnelStatus',
+      payload: { UserId: 'due-user' },
+      retries: 1,
+      attempts: 1,
+      nextRetryAt: now,
+    };
+    storage.getString.mockReturnValue(JSON.stringify([futureItem, dueItem]));
+
+    await processor.processQueue();
+
+    expect(savePersonnelStatus).toHaveBeenCalledTimes(1);
+    expect(savePersonnelStatus).toHaveBeenCalledWith(dueItem.payload);
+    expect(JSON.parse(storage.set.mock.calls[0][1])).toEqual([futureItem]);
+  });
+
+  it('preserves an item enqueued while queue processing is in progress', async () => {
+    let storedQueue = JSON.stringify([
+      {
+        id: 'existing',
+        type: 'personnelStatus',
+        payload: { UserId: 'existing-user' },
+        retries: 0,
+        attempts: 0,
+      },
+    ]);
+    storage.getString.mockImplementation(() => storedQueue);
+    storage.set.mockImplementation((_key: string, value: string) => {
+      storedQueue = value;
+      return Promise.resolve();
+    });
+
+    let signalProcessingStarted: () => void;
+    const processingStarted = new Promise<void>((resolve) => {
+      signalProcessingStarted = resolve;
+    });
+    let finishProcessing: () => void;
+    const processingBlocked = new Promise<void>((resolve) => {
+      finishProcessing = resolve;
+    });
+    savePersonnelStatus.mockImplementation(() => {
+      signalProcessingStarted!();
+      return processingBlocked;
+    });
+
+    const processing = processor.processQueue();
+    await processingStarted;
+
+    const queuedId = processor.addPersonnelStatusToQueue({ UserId: 'new-user' });
+    finishProcessing!();
+
+    await processing;
+    await processor.queueMutationChain;
+
+    expect(queuedId).toEqual(expect.any(String));
+    expect(JSON.parse(storedQueue)).toEqual([
+      expect.objectContaining({
+        id: queuedId,
+        payload: expect.objectContaining({ UserId: 'new-user' }),
+      }),
+    ]);
   });
 });

--- a/src/services/__tests__/signalr.service.test.ts
+++ b/src/services/__tests__/signalr.service.test.ts
@@ -672,6 +672,58 @@ describe('SignalRService', () => {
       connectSpy.mockRestore();
     });
 
+    it('should skip a reconnect timer when an intentional disconnect is already marked', async () => {
+      jest.useFakeTimers();
+      (signalRService as any).hubConfigs.set(mockConfig.name, mockConfig);
+      (signalRService as any).intentionalDisconnects.add(mockConfig.name);
+      const eventingConnectSpy = jest.spyOn(signalRService, 'connectToHubWithEventingUrl').mockResolvedValue();
+      const directConnectSpy = jest.spyOn(signalRService, 'connectToHub').mockResolvedValue();
+
+      await (signalRService as any).attemptReconnection(mockConfig.name, 0);
+      jest.advanceTimersByTime(6000);
+      await jest.runAllTicks();
+
+      expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+      expect(eventingConnectSpy).not.toHaveBeenCalled();
+      expect(directConnectSpy).not.toHaveBeenCalled();
+      expect((signalRService as any).intentionalDisconnects.has(mockConfig.name)).toBe(false);
+
+      jest.useRealTimers();
+      eventingConnectSpy.mockRestore();
+      directConnectSpy.mockRestore();
+    });
+
+    it('should skip reconnection when an intentional disconnect is marked during token refresh', async () => {
+      jest.useFakeTimers();
+      (signalRService as any).hubConfigs.set(mockConfig.name, mockConfig);
+      let resolveRefresh: () => void;
+      mockRefreshAccessToken.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+      const eventingConnectSpy = jest.spyOn(signalRService, 'connectToHubWithEventingUrl').mockResolvedValue();
+      const directConnectSpy = jest.spyOn(signalRService, 'connectToHub').mockResolvedValue();
+
+      await (signalRService as any).attemptReconnection(mockConfig.name, 0);
+      jest.advanceTimersByTime(6000);
+      expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+
+      (signalRService as any).intentionalDisconnects.add(mockConfig.name);
+      resolveRefresh!();
+      await jest.runAllTicks();
+      await Promise.resolve();
+
+      expect(eventingConnectSpy).not.toHaveBeenCalled();
+      expect(directConnectSpy).not.toHaveBeenCalled();
+      expect((signalRService as any).intentionalDisconnects.has(mockConfig.name)).toBe(false);
+
+      jest.useRealTimers();
+      eventingConnectSpy.mockRestore();
+      directConnectSpy.mockRestore();
+    });
+
     it('should reset reconnection attempts on successful reconnection', async () => {
       // Test that successful reconnection resets the attempt counter
       

--- a/src/services/__tests__/signalr.service.test.ts
+++ b/src/services/__tests__/signalr.service.test.ts
@@ -52,6 +52,8 @@ describe('SignalRService', () => {
     (signalRService as any).connectionLocks.clear();
     (signalRService as any).reconnectingHubs.clear();
     (signalRService as any).hubStates.clear();
+    (signalRService as any).intentionalDisconnects.clear();
+    (signalRService as any).reconnectTimers.clear();
 
     // Mock HubConnection
     mockConnection = {
@@ -104,7 +106,7 @@ describe('SignalRService', () => {
         })
       );
       expect(mockBuilderInstance.withAutomaticReconnect).toHaveBeenCalledWith([0, 2000, 5000, 10000, 30000]);
-      expect(mockBuilderInstance.configureLogging).toHaveBeenCalledWith(LogLevel.Information);
+      expect(mockBuilderInstance.configureLogging).toHaveBeenCalledWith(LogLevel.Warning);
       expect(mockConnection.start).toHaveBeenCalled();
     });
 
@@ -600,6 +602,74 @@ describe('SignalRService', () => {
       });
       
       attemptReconnectionSpy.mockRestore();
+    });
+
+    it('should not reconnect after an intentional disconnect', async () => {
+      // Connect to hub
+      await signalRService.connectToHubWithEventingUrl(mockConfig);
+
+      // Get the onclose callback registered on the connection
+      const onCloseCallback = mockConnection.onclose.mock.calls[0]?.[0];
+      expect(onCloseCallback).toBeDefined();
+
+      // Simulate the real SignalR behavior where stop() fires onclose
+      mockConnection.stop.mockImplementation(async () => {
+        onCloseCallback?.();
+      });
+
+      jest.useFakeTimers();
+
+      // Intentionally disconnect
+      await signalRService.disconnectFromHub(mockConfig.name);
+
+      // Hub should not be marked as reconnecting
+      expect((signalRService as any).hubStates.get(mockConfig.name)).toBeUndefined();
+      expect((signalRService as any).reconnectingHubs.has(mockConfig.name)).toBe(false);
+
+      // No reconnection timer should be pending
+      expect((signalRService as any).reconnectTimers.has(mockConfig.name)).toBe(false);
+
+      // Advancing time should not schedule any reconnection work
+      jest.advanceTimersByTime(60000);
+      await jest.runAllTicks();
+
+      expect((signalRService as any).hubStates.get(mockConfig.name)).toBeUndefined();
+
+      jest.useRealTimers();
+    });
+
+    it('should cancel a pending reconnection timer on intentional disconnect', async () => {
+      // Connect to hub
+      await signalRService.connectToHubWithEventingUrl(mockConfig);
+
+      const onCloseCallback = mockConnection.onclose.mock.calls[0]?.[0];
+
+      const connectSpy = jest.spyOn(signalRService, 'connectToHubWithEventingUrl');
+
+      jest.useFakeTimers();
+
+      // Simulate an unintentional connection drop to schedule a reconnect
+      onCloseCallback?.();
+
+      // A reconnect timer should now be pending
+      expect((signalRService as any).reconnectTimers.has(mockConfig.name)).toBe(true);
+
+      // Intentionally disconnect before the timer fires
+      await signalRService.disconnectFromHub(mockConfig.name);
+
+      // Pending timer must be cancelled
+      expect((signalRService as any).reconnectTimers.has(mockConfig.name)).toBe(false);
+
+      connectSpy.mockClear();
+
+      jest.advanceTimersByTime(60000);
+      await jest.runAllTicks();
+
+      // Reconnection should not have been attempted
+      expect(connectSpy).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
+      connectSpy.mockRestore();
     });
 
     it('should reset reconnection attempts on successful reconnection', async () => {

--- a/src/services/app-initialization.service.ts
+++ b/src/services/app-initialization.service.ts
@@ -71,11 +71,9 @@ class AppInitializationService {
       message: 'Starting app initialization',
     });
 
-    // Initialize analytics service
-    await this._initializeAnalytics();
-
-    // Initialize CallKeep for iOS background audio support
-    await this._initializeCallKeep();
+    // Analytics and CallKeep are independent - initialize concurrently.
+    // Each handles its own errors internally and never throws.
+    await Promise.all([this._initializeAnalytics(), this._initializeCallKeep()]);
 
     // Add other global initialization tasks here as needed
     // e.g., crash reporting, background services, etc.

--- a/src/services/location.ts
+++ b/src/services/location.ts
@@ -119,6 +119,7 @@ TaskManager.defineTask(LOCATION_TASK_NAME, async ({ data, error }) => {
 class LocationService {
   private static instance: LocationService;
   private locationSubscription: Location.LocationSubscription | null = null;
+  private startLocationUpdatesPromise: Promise<void> | null = null;
   private appStateSubscription: { remove: () => void } | null = null;
   private isBackgroundGeolocationEnabled = false;
   private isRealtimeGeolocationEnabled = false;
@@ -165,7 +166,17 @@ class LocationService {
     return foregroundStatus === 'granted';
   }
 
-  async startLocationUpdates(): Promise<void> {
+  startLocationUpdates(): Promise<void> {
+    if (!this.startLocationUpdatesPromise) {
+      this.startLocationUpdatesPromise = this.startLocationUpdatesInternal().finally(() => {
+        this.startLocationUpdatesPromise = null;
+      });
+    }
+
+    return this.startLocationUpdatesPromise;
+  }
+
+  private async startLocationUpdatesInternal(): Promise<void> {
     const hasPermissions = await this.requestPermissions();
     if (!hasPermissions) {
       throw new Error('Location permissions not granted');

--- a/src/services/location.ts
+++ b/src/services/location.ts
@@ -168,9 +168,17 @@ class LocationService {
 
   startLocationUpdates(): Promise<void> {
     if (!this.startLocationUpdatesPromise) {
-      this.startLocationUpdatesPromise = this.startLocationUpdatesInternal().finally(() => {
-        this.startLocationUpdatesPromise = null;
-      });
+      this.startLocationUpdatesPromise = this.startLocationUpdatesInternal()
+        .catch((error) => {
+          logger.error({
+            message: 'Failed to start location updates',
+            context: { error },
+          });
+          throw error;
+        })
+        .finally(() => {
+          this.startLocationUpdatesPromise = null;
+        });
     }
 
     return this.startLocationUpdatesPromise;

--- a/src/services/location.ts
+++ b/src/services/location.ts
@@ -201,6 +201,12 @@ class LocationService {
       }
     }
 
+    // Remove any existing foreground subscription so repeated calls stay idempotent
+    if (this.locationSubscription) {
+      this.locationSubscription.remove();
+      this.locationSubscription = null;
+    }
+
     // Start foreground updates
     this.locationSubscription = await Location.watchPositionAsync(
       {

--- a/src/services/offline-queue-processor.ts
+++ b/src/services/offline-queue-processor.ts
@@ -1,11 +1,17 @@
 import NetInfo from '@react-native-community/netinfo';
+import CryptoJS from 'crypto-js';
 
 import { savePersonnelStatus } from '@/api/personnel/personnelStatuses';
+import { Env } from '@/lib/env';
 import { logger } from '@/lib/logging';
 import { getOfflineQueueStorage } from '@/lib/storage/secure-storage';
 import type { SavePersonStatusInput } from '@/models/v4/personnelStatuses/savePersonStatusInput';
 
 const MAX_RETRIES = 5;
+
+const hashDiagnosticIdentifier = (identifier: string): string | null => {
+  return identifier ? CryptoJS.HmacSHA256(identifier, Env.LOGGING_KEY || '').toString() : null;
+};
 
 interface QueueItem {
   id: string;
@@ -13,12 +19,14 @@ interface QueueItem {
   payload: SavePersonStatusInput;
   retries: number;
   attempts?: number;
+  nextRetryAt?: number;
 }
 
-class RealOfflineQueueProcessor {
+export class RealOfflineQueueProcessor {
   private static instance: RealOfflineQueueProcessor | null = null;
   private processing = false;
   private storageKey = 'offline_queue';
+  private queueMutationChain: Promise<void> = Promise.resolve();
 
   private constructor() {
     NetInfo.addEventListener((state) => {
@@ -49,32 +57,48 @@ class RealOfflineQueueProcessor {
     }
   }
 
+  private serializeQueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    const result = this.queueMutationChain.then(mutation);
+    this.queueMutationChain = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
   async processQueue(): Promise<void> {
     if (this.processing) return;
     this.processing = true;
     try {
-      const storage = await getOfflineQueueStorage();
-      const items = await this.readQueue(storage);
-      const remaining: QueueItem[] = [];
-      for (const item of items) {
-        try {
-          if (item.type === 'personnelStatus') {
-            await savePersonnelStatus(item.payload);
-          }
-        } catch (error) {
-          item.retries++;
-          item.attempts = (item.attempts ?? item.retries - 1) + 1;
-          if (item.attempts >= MAX_RETRIES) {
-            logger.error({ message: 'Dropping offline queue item after max retries', context: { id: item.id, attempts: item.attempts, error } });
+      await this.serializeQueueMutation(async () => {
+        const storage = await getOfflineQueueStorage();
+        const items = await this.readQueue(storage);
+        const remaining: QueueItem[] = [];
+        for (const item of items) {
+          if (item.nextRetryAt && item.nextRetryAt > Date.now()) {
+            remaining.push(item);
             continue;
           }
-          const backoff = Math.min(2 ** item.retries * 1000, 30000);
-          await new Promise((resolve) => setTimeout(resolve, backoff));
-          remaining.push(item);
-          logger.warn({ message: 'Retrying offline queue item', context: { id: item.id, attempts: item.attempts, error } });
+
+          try {
+            if (item.type === 'personnelStatus') {
+              await savePersonnelStatus(item.payload);
+            }
+          } catch (error) {
+            item.retries++;
+            item.attempts = (item.attempts ?? item.retries - 1) + 1;
+            if (item.attempts >= MAX_RETRIES) {
+              logger.error({ message: 'Dropping offline queue item after max retries', context: { id: item.id, attempts: item.attempts, error } });
+              continue;
+            }
+            const backoff = Math.min(2 ** item.retries * 1000, 30000);
+            item.nextRetryAt = Date.now() + backoff;
+            remaining.push(item);
+            logger.warn({ message: 'Scheduled offline queue item retry', context: { id: item.id, attempts: item.attempts, nextRetryAt: item.nextRetryAt, error } });
+          }
         }
-      }
-      await storage.set(this.storageKey, JSON.stringify(remaining));
+        await storage.set(this.storageKey, JSON.stringify(remaining));
+      });
     } catch (error) {
       logger.error({ message: 'Processing offline queue failed', context: { error } });
     } finally {
@@ -90,11 +114,13 @@ class RealOfflineQueueProcessor {
     return id;
   }
 
-  private async enqueue(item: QueueItem): Promise<void> {
-    const storage = await getOfflineQueueStorage();
-    const items = await this.readQueue(storage);
-    items.push(item);
-    await storage.set(this.storageKey, JSON.stringify(items));
+  private enqueue(item: QueueItem): Promise<void> {
+    return this.serializeQueueMutation(async () => {
+      const storage = await getOfflineQueueStorage();
+      const items = await this.readQueue(storage);
+      items.push(item);
+      await storage.set(this.storageKey, JSON.stringify(items));
+    });
   }
 
   cleanup(): void {
@@ -132,7 +158,15 @@ class StubOfflineQueueProcessor {
       logger.error({ message: 'Stub offline queue used in production' });
       throw new Error('OfflineQueueProcessor stub used in production');
     }
-    logger.warn({ message: 'Stub offline queue: dropping personnel status item (non-production environment)', context: { status } });
+    logger.warn({
+      message: 'Stub offline queue: dropping personnel status item (non-production environment)',
+      context: {
+        userIdHash: hashDiagnosticIdentifier(status.UserId),
+        eventIdHash: hashDiagnosticIdentifier(status.EventId),
+        lawful_basis: 'legitimate_interests',
+        purpose: 'offline_queue_diagnostics',
+      },
+    });
     return '';
   }
   cleanup(): void {

--- a/src/services/offline-queue-processor.ts
+++ b/src/services/offline-queue-processor.ts
@@ -5,11 +5,14 @@ import { logger } from '@/lib/logging';
 import { getOfflineQueueStorage } from '@/lib/storage/secure-storage';
 import type { SavePersonStatusInput } from '@/models/v4/personnelStatuses/savePersonStatusInput';
 
+const MAX_RETRIES = 5;
+
 interface QueueItem {
   id: string;
   type: 'personnelStatus';
   payload: SavePersonStatusInput;
   retries: number;
+  attempts?: number;
 }
 
 class RealOfflineQueueProcessor {
@@ -20,7 +23,9 @@ class RealOfflineQueueProcessor {
   private constructor() {
     NetInfo.addEventListener((state) => {
       if (state.isInternetReachable) {
-        this.processQueue();
+        void this.processQueue().catch((error) => {
+          logger.error({ message: 'Offline queue processing failed on network change', context: { error } });
+        });
       }
     });
   }
@@ -32,13 +37,24 @@ class RealOfflineQueueProcessor {
     return RealOfflineQueueProcessor.instance!;
   }
 
+  private async readQueue(storage: Awaited<ReturnType<typeof getOfflineQueueStorage>>): Promise<QueueItem[]> {
+    const raw = storage.getString(this.storageKey);
+    if (!raw) return [];
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return Array.isArray(parsed) ? (parsed as QueueItem[]) : [];
+    } catch (error) {
+      logger.warn({ message: 'Corrupt offline queue data, resetting queue', context: { error } });
+      return [];
+    }
+  }
+
   async processQueue(): Promise<void> {
     if (this.processing) return;
     this.processing = true;
     try {
       const storage = await getOfflineQueueStorage();
-      const raw = storage.getString(this.storageKey);
-      const items: QueueItem[] = raw ? JSON.parse(raw) : [];
+      const items = await this.readQueue(storage);
       const remaining: QueueItem[] = [];
       for (const item of items) {
         try {
@@ -47,10 +63,15 @@ class RealOfflineQueueProcessor {
           }
         } catch (error) {
           item.retries++;
+          item.attempts = (item.attempts ?? item.retries - 1) + 1;
+          if (item.attempts >= MAX_RETRIES) {
+            logger.error({ message: 'Dropping offline queue item after max retries', context: { id: item.id, attempts: item.attempts, error } });
+            continue;
+          }
           const backoff = Math.min(2 ** item.retries * 1000, 30000);
           await new Promise((resolve) => setTimeout(resolve, backoff));
           remaining.push(item);
-          logger.warn({ message: 'Retrying offline queue item', context: { id: item.id, error } });
+          logger.warn({ message: 'Retrying offline queue item', context: { id: item.id, attempts: item.attempts, error } });
         }
       }
       await storage.set(this.storageKey, JSON.stringify(remaining));
@@ -63,14 +84,15 @@ class RealOfflineQueueProcessor {
 
   addPersonnelStatusToQueue(status: SavePersonStatusInput): string {
     const id = `${Date.now()}-${Math.random()}`;
-    this.enqueue({ id, type: 'personnelStatus', payload: status, retries: 0 });
+    void this.enqueue({ id, type: 'personnelStatus', payload: status, retries: 0, attempts: 0 }).catch((error) => {
+      logger.error({ message: 'Failed to enqueue personnel status', context: { id, error } });
+    });
     return id;
   }
 
   private async enqueue(item: QueueItem): Promise<void> {
     const storage = await getOfflineQueueStorage();
-    const raw = storage.getString(this.storageKey);
-    const items: QueueItem[] = raw ? JSON.parse(raw) : [];
+    const items = await this.readQueue(storage);
     items.push(item);
     await storage.set(this.storageKey, JSON.stringify(items));
   }
@@ -102,6 +124,7 @@ class StubOfflineQueueProcessor {
       logger.error({ message: 'Stub offline queue used in production' });
       throw new Error('OfflineQueueProcessor stub used in production');
     }
+    logger.warn({ message: 'Stub offline queue active: queued items are NOT persisted or processed (non-production environment)' });
     return Promise.resolve();
   }
   addPersonnelStatusToQueue(status: SavePersonStatusInput): string {
@@ -109,6 +132,7 @@ class StubOfflineQueueProcessor {
       logger.error({ message: 'Stub offline queue used in production' });
       throw new Error('OfflineQueueProcessor stub used in production');
     }
+    logger.warn({ message: 'Stub offline queue: dropping personnel status item (non-production environment)', context: { status } });
     return '';
   }
   cleanup(): void {

--- a/src/services/offline-queue.service.ts
+++ b/src/services/offline-queue.service.ts
@@ -55,6 +55,8 @@ export class OfflineQueueService {
     try {
       offlineQueueProcessor.cleanup();
 
+      useOfflineQueueStore.getState().teardownNetworkListener();
+
       this.initialized = false;
 
       logger.info({

--- a/src/services/push-notification.ts
+++ b/src/services/push-notification.ts
@@ -62,6 +62,20 @@ class PushNotificationService {
   // response twice (once from getLastNotificationResponseAsync and once from the response listener).
   private lastHandledResponseId: string | null = null;
 
+  private static toErrorContext(error: unknown): { errorMessage: string; errorName: string } {
+    return {
+      errorMessage: error instanceof Error ? error.message : String(error),
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+    };
+  }
+
+  private static truncateToken(token: string): string {
+    if (token.length <= 12) {
+      return `${token.slice(0, 4)}…`;
+    }
+    return `${token.slice(0, 8)}…${token.slice(-4)}`;
+  }
+
   private constructor() {
     this.initialize();
   }
@@ -116,7 +130,7 @@ class PushNotificationService {
     } catch (error) {
       logger.error({
         message: 'Error setting up Android notification channels',
-        context: { error },
+        context: { ...PushNotificationService.toErrorContext(error) },
       });
     }
   }
@@ -147,7 +161,7 @@ class PushNotificationService {
     } catch (error) {
       logger.error({
         message: 'Error handling launch notification response',
-        context: { error },
+        context: { ...PushNotificationService.toErrorContext(error) },
       });
     }
   };
@@ -178,10 +192,11 @@ class PushNotificationService {
   };
 
   private handleNotificationReceived = (notification: Notifications.Notification): void => {
+    const data = notification.request.content.data;
     logger.info({
       message: 'Notification received',
       context: {
-        data: notification.request.content.data,
+        eventCode: typeof data?.eventCode === 'string' ? data.eventCode : undefined,
       },
     });
 
@@ -201,7 +216,7 @@ class PushNotificationService {
     logger.info({
       message: 'Notification response received',
       context: {
-        data: response.notification.request.content.data,
+        eventCode: typeof response.notification.request.content.data?.eventCode === 'string' ? (response.notification.request.content.data.eventCode as string) : undefined,
       },
     });
 
@@ -231,7 +246,7 @@ class PushNotificationService {
     } catch (error) {
       logger.error({
         message: 'Failed to navigate to weather alert from push notification',
-        context: { error, alertId },
+        context: { ...PushNotificationService.toErrorContext(error), alertId },
       });
     }
   };
@@ -279,7 +294,7 @@ class PushNotificationService {
       logger.info({
         message: 'Push notification token obtained',
         context: {
-          token: this.pushToken,
+          tokenPreview: PushNotificationService.truncateToken(this.pushToken),
           userId,
           platform: Platform.OS,
         },
@@ -297,7 +312,7 @@ class PushNotificationService {
     } catch (error) {
       logger.error({
         message: 'Error registering for push notifications',
-        context: { error },
+        context: { ...PushNotificationService.toErrorContext(error) },
       });
       return null;
     }
@@ -332,7 +347,7 @@ class PushNotificationService {
     } catch (error) {
       logger.error({
         message: 'Failed to send test notification',
-        context: { error },
+        context: { ...PushNotificationService.toErrorContext(error) },
       });
     }
   }
@@ -374,7 +389,10 @@ export const usePushNotifications = () => {
         .catch((error) => {
           logger.error({
             message: 'Error in push notification registration hook',
-            context: { error },
+            context: {
+              errorMessage: error instanceof Error ? error.message : String(error),
+              errorName: error instanceof Error ? error.name : 'UnknownError',
+            },
           });
         });
 

--- a/src/services/signalr.service.ts
+++ b/src/services/signalr.service.ts
@@ -96,6 +96,15 @@ class SignalRService {
     }
   }
 
+  private consumeIntentionalDisconnect(hubName: string): boolean {
+    if (!this.intentionalDisconnects.has(hubName)) {
+      return false;
+    }
+
+    this.intentionalDisconnects.delete(hubName);
+    return true;
+  }
+
   public async connectToHubWithEventingUrl(config: SignalRHubConnectConfig): Promise<void> {
     // Check for existing lock to prevent concurrent connections to the same hub
     const existingLock = this.connectionLocks.get(config.name);
@@ -424,8 +433,7 @@ class SignalRService {
   }
 
   private handleConnectionClose(hubName: string): void {
-    if (this.intentionalDisconnects.has(hubName)) {
-      this.intentionalDisconnects.delete(hubName);
+    if (this.consumeIntentionalDisconnect(hubName)) {
       logger.debug({
         message: `Hub ${hubName} closed due to intentional disconnect, skipping reconnection`,
       });
@@ -489,8 +497,7 @@ class SignalRService {
 
     const timer = setTimeout(async () => {
       this.reconnectTimers.delete(hubName);
-      if (this.intentionalDisconnects.has(hubName)) {
-        this.intentionalDisconnects.delete(hubName);
+      if (this.consumeIntentionalDisconnect(hubName)) {
         return;
       }
 
@@ -533,8 +540,7 @@ class SignalRService {
 
           await useAuthStore.getState().refreshAccessToken();
 
-          if (this.intentionalDisconnects.has(hubName)) {
-            this.intentionalDisconnects.delete(hubName);
+          if (this.consumeIntentionalDisconnect(hubName)) {
             return;
           }
 

--- a/src/services/signalr.service.ts
+++ b/src/services/signalr.service.ts
@@ -489,6 +489,11 @@ class SignalRService {
 
     const timer = setTimeout(async () => {
       this.reconnectTimers.delete(hubName);
+      if (this.intentionalDisconnects.has(hubName)) {
+        this.intentionalDisconnects.delete(hubName);
+        return;
+      }
+
       try {
         // Check if the hub config was removed (e.g., by explicit disconnect)
         const currentHubConfig = this.hubConfigs.get(hubName);
@@ -527,6 +532,11 @@ class SignalRService {
           });
 
           await useAuthStore.getState().refreshAccessToken();
+
+          if (this.intentionalDisconnects.has(hubName)) {
+            this.intentionalDisconnects.delete(hubName);
+            return;
+          }
 
           // Verify we have a valid token after refresh
           const token = useAuthStore.getState().accessToken;

--- a/src/services/signalr.service.ts
+++ b/src/services/signalr.service.ts
@@ -36,6 +36,8 @@ class SignalRService {
   private connectionLocks: Map<string, Promise<void>> = new Map();
   private reconnectingHubs: Set<string> = new Set();
   private hubStates: Map<string, HubConnectingState> = new Map();
+  private intentionalDisconnects: Set<string> = new Set();
+  private reconnectTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private readonly MAX_RECONNECT_ATTEMPTS = 5;
   private readonly RECONNECT_INTERVAL = 5000; // 5 seconds
 
@@ -212,7 +214,7 @@ class SignalRService {
               }
         )
         .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
-        .configureLogging(LogLevel.Information);
+        .configureLogging(LogLevel.Warning);
 
       const connection = connectionBuilder.build();
 
@@ -357,7 +359,7 @@ class SignalRService {
           accessTokenFactory: () => token,
         })
         .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
-        .configureLogging(LogLevel.Information)
+        .configureLogging(LogLevel.Warning)
         .build();
 
       // Set up event handlers
@@ -422,6 +424,14 @@ class SignalRService {
   }
 
   private handleConnectionClose(hubName: string): void {
+    if (this.intentionalDisconnects.has(hubName)) {
+      this.intentionalDisconnects.delete(hubName);
+      logger.debug({
+        message: `Hub ${hubName} closed due to intentional disconnect, skipping reconnection`,
+      });
+      return;
+    }
+
     // Immediately set the hub status to RECONNECTING
     this.hubStates.set(hubName, HubConnectingState.RECONNECTING);
     this.reconnectingHubs.add(hubName);
@@ -477,7 +487,8 @@ class SignalRService {
     const jitter = Math.random() * 1000; // Add up to 1 second of jitter
     const delay = baseDelay * backoffMultiplier + jitter;
 
-    setTimeout(async () => {
+    const timer = setTimeout(async () => {
+      this.reconnectTimers.delete(hubName);
       try {
         // Check if the hub config was removed (e.g., by explicit disconnect)
         const currentHubConfig = this.hubConfigs.get(hubName);
@@ -569,6 +580,7 @@ class SignalRService {
         this.attemptReconnection(hubName, currentAttempts);
       }
     }, delay);
+    this.reconnectTimers.set(hubName, timer);
   }
 
   private handleMessage(hubName: string, method: string, data: unknown): void {
@@ -598,10 +610,18 @@ class SignalRService {
       }
     }
 
+    const pendingTimer = this.reconnectTimers.get(hubName);
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      this.reconnectTimers.delete(hubName);
+    }
+
     const connection = this.connections.get(hubName);
     if (connection) {
       try {
+        this.intentionalDisconnects.add(hubName);
         await connection.stop();
+        this.intentionalDisconnects.delete(hubName);
         this.connections.delete(hubName);
         this.reconnectAttempts.delete(hubName);
         this.hubConfigs.delete(hubName);
@@ -611,6 +631,7 @@ class SignalRService {
           message: `Disconnected from hub: ${hubName}`,
         });
       } catch (error) {
+        this.intentionalDisconnects.delete(hubName);
         logger.error({
           message: `Error disconnecting from hub: ${hubName}`,
           context: { error },

--- a/src/stores/app/__tests__/location-store.test.ts
+++ b/src/stores/app/__tests__/location-store.test.ts
@@ -138,6 +138,39 @@ describe('useLocationStore', () => {
     });
   });
 
+  it('should persist only durable preferences, not live location data', () => {
+    const { zustandStorage } = require('@/lib/storage');
+    const { result } = renderHook(() => useLocationStore());
+
+    act(() => {
+      result.current.setLocation({
+        coords: {
+          latitude: 40.7128,
+          longitude: -74.006,
+          heading: 180,
+          accuracy: 5,
+          speed: 0,
+          altitude: 10,
+          altitudeAccuracy: 5,
+        },
+        timestamp: 1640995200000,
+      });
+      result.current.setMapLocked(true);
+      result.current.setBackgroundEnabled(true);
+    });
+
+    const persistedRaw = zustandStorage.getItem('location-storage');
+    expect(persistedRaw).toBeTruthy();
+
+    const persisted = JSON.parse(persistedRaw as string);
+    expect(persisted.state.isMapLocked).toBe(true);
+    expect(persisted.state.isBackgroundEnabled).toBe(true);
+    expect(persisted.state.latitude).toBeUndefined();
+    expect(persisted.state.longitude).toBeUndefined();
+    expect(persisted.state.heading).toBeUndefined();
+    expect(persisted.state.timestamp).toBeUndefined();
+  });
+
   it('should have all required methods', () => {
     const { result } = renderHook(() => useLocationStore());
 

--- a/src/stores/app/__tests__/location-store.test.ts
+++ b/src/stores/app/__tests__/location-store.test.ts
@@ -171,6 +171,37 @@ describe('useLocationStore', () => {
     expect(persisted.state.timestamp).toBeUndefined();
   });
 
+  it('should remove legacy coordinates during storage migration', async () => {
+    const { zustandStorage } = require('@/lib/storage');
+    await zustandStorage.setItem(
+      'location-storage',
+      JSON.stringify({
+        state: {
+          latitude: 40.7128,
+          longitude: -74.006,
+          isBackgroundEnabled: true,
+          isMapLocked: true,
+        },
+        version: 0,
+      })
+    );
+
+    await act(async () => {
+      await useLocationStore.persist.rehydrate();
+    });
+
+    const state = useLocationStore.getState();
+    expect(state.latitude).toBeNull();
+    expect(state.longitude).toBeNull();
+    expect(state.isBackgroundEnabled).toBe(true);
+    expect(state.isMapLocked).toBe(true);
+
+    const persisted = JSON.parse((await zustandStorage.getItem('location-storage')) as string);
+    expect(persisted.version).toBe(1);
+    expect(persisted.state.latitude).toBeUndefined();
+    expect(persisted.state.longitude).toBeUndefined();
+  });
+
   it('should have all required methods', () => {
     const { result } = renderHook(() => useLocationStore());
 

--- a/src/stores/app/location-store.ts
+++ b/src/stores/app/location-store.ts
@@ -47,6 +47,16 @@ export const useLocationStore = create<LocationState>()(
     {
       name: 'location-storage',
       storage: createJSONStorage(() => zustandStorage),
+      version: 1,
+      migrate: (persistedState, version) => {
+        if (version < 1 && persistedState && typeof persistedState === 'object') {
+          const migratedState = { ...(persistedState as Partial<LocationState>) };
+          delete migratedState.latitude;
+          delete migratedState.longitude;
+          return migratedState as LocationState;
+        }
+        return persistedState as LocationState;
+      },
       partialize: (state) => ({
         isBackgroundEnabled: state.isBackgroundEnabled,
         isMapLocked: state.isMapLocked,

--- a/src/stores/app/location-store.ts
+++ b/src/stores/app/location-store.ts
@@ -47,6 +47,10 @@ export const useLocationStore = create<LocationState>()(
     {
       name: 'location-storage',
       storage: createJSONStorage(() => zustandStorage),
+      partialize: (state) => ({
+        isBackgroundEnabled: state.isBackgroundEnabled,
+        isMapLocked: state.isMapLocked,
+      }),
     }
   )
 );

--- a/src/stores/auth/__tests__/store-login-hydration.test.ts
+++ b/src/stores/auth/__tests__/store-login-hydration.test.ts
@@ -47,6 +47,11 @@ jest.mock('@/lib/storage/app', () => ({
   getBaseApiUrl: jest.fn(() => 'https://mock-api.com/api/v1'),
 }));
 
+jest.mock('@/lib/storage/clear-all-data', () => ({
+  clearAllAppData: jest.fn().mockResolvedValue(undefined),
+  LOGOUT_PRESERVED_STORAGE_KEYS: ['baseUrl', 'IS_FIRST_TIME'],
+}));
+
 import { loginRequest } from '@/lib/auth/api';
 import { getAuth } from '@/lib/auth/utils';
 import useAuthStore from '../store';

--- a/src/stores/auth/__tests__/store-logout.test.ts
+++ b/src/stores/auth/__tests__/store-logout.test.ts
@@ -47,10 +47,19 @@ jest.mock('@/lib/storage/app', () => ({
   getBaseApiUrl: jest.fn(() => 'https://mock-api.com/api/v1'),
 }));
 
+jest.mock('@/lib/storage/clear-all-data', () => ({
+  clearAllAppData: jest.fn().mockResolvedValue(undefined),
+  LOGOUT_PRESERVED_STORAGE_KEYS: ['baseUrl', 'IS_FIRST_TIME'],
+}));
+
+import * as SecureStore from 'expo-secure-store';
+
+import { clearAllAppData } from '@/lib/storage/clear-all-data';
 import useAuthStore from '../store';
 
 const mockedRemoveItem = removeItem as jest.MockedFunction<typeof removeItem>;
 const mockedLogger = logger as jest.Mocked<typeof logger>;
+const mockedClearAllAppData = clearAllAppData as jest.MockedFunction<typeof clearAllAppData>;
 
 describe('Auth Store - Logout Functionality', () => {
   beforeEach(() => {
@@ -75,6 +84,16 @@ describe('Auth Store - Logout Functionality', () => {
 
       // Verify authResponse was removed from storage
       expect(mockedRemoveItem).toHaveBeenCalledWith('authResponse');
+
+      expect(mockedClearAllAppData).toHaveBeenCalledWith({
+        resetStores: true,
+        clearStorage: true,
+        clearFilters: true,
+        clearSecure: false,
+        preserveStorageKeys: ['baseUrl', 'IS_FIRST_TIME'],
+      });
+
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('pending_saml_state');
 
       // Verify auth state was reset
       const state = useAuthStore.getState();
@@ -102,6 +121,22 @@ describe('Auth Store - Logout Functionality', () => {
       });
 
       // Verify auth state was still reset
+      const state = useAuthStore.getState();
+      expect(state.accessToken).toBeNull();
+      expect(state.status).toBe('signedOut');
+    });
+
+    it('should log warning if clearAllAppData fails but still reset auth state', async () => {
+      const mockError = new Error('Cleanup error');
+      mockedClearAllAppData.mockRejectedValueOnce(mockError);
+
+      await useAuthStore.getState().logout();
+
+      expect(mockedLogger.warn).toHaveBeenCalledWith({
+        message: 'Failed to clear app data during logout',
+        context: { error: mockError, reason: undefined },
+      });
+
       const state = useAuthStore.getState();
       expect(state.accessToken).toBeNull();
       expect(state.status).toBe('signedOut');

--- a/src/stores/auth/__tests__/store-token-refresh.test.ts
+++ b/src/stores/auth/__tests__/store-token-refresh.test.ts
@@ -47,6 +47,11 @@ jest.mock('@/lib/storage/app', () => ({
   getBaseApiUrl: jest.fn(() => 'https://mock-api.com/api/v1'),
 }));
 
+jest.mock('@/lib/storage/clear-all-data', () => ({
+  clearAllAppData: jest.fn().mockResolvedValue(undefined),
+  LOGOUT_PRESERVED_STORAGE_KEYS: ['baseUrl', 'IS_FIRST_TIME'],
+}));
+
 import { refreshTokenRequest } from '@/lib/auth/api';
 import useAuthStore from '../store';
 
@@ -123,6 +128,64 @@ describe('Auth Store - Token Refresh Functionality', () => {
           newAccessTokenObtainedAt: expect.any(Number),
         },
       });
+    });
+
+    it('should share a single in-flight refresh between concurrent callers', async () => {
+      type RefreshResponse = Awaited<ReturnType<typeof refreshTokenRequest>>;
+      let resolveRefresh: (value: RefreshResponse) => void = () => undefined;
+      mockedRefreshTokenRequest.mockImplementationOnce(
+        () =>
+          new Promise<RefreshResponse>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+      const first = useAuthStore.getState().refreshAccessToken();
+      const second = useAuthStore.getState().refreshAccessToken();
+
+      resolveRefresh({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        id_token: 'new-id-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+        expiration_date: new Date(Date.now() + 3600 * 1000).toISOString(),
+      });
+
+      await Promise.all([first, second]);
+
+      expect(mockedRefreshTokenRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('should start a new refresh once the in-flight one settles', async () => {
+      const mockResponse = {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        id_token: 'new-id-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+        expiration_date: new Date(Date.now() + 3600 * 1000).toISOString(),
+      };
+
+      mockedRefreshTokenRequest.mockResolvedValue(mockResponse);
+
+      await useAuthStore.getState().refreshAccessToken();
+      await useAuthStore.getState().refreshAccessToken();
+
+      expect(mockedRefreshTokenRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('should propagate transient errors to all concurrent callers', async () => {
+      const mockError = new Error('Network request failed');
+      mockedRefreshTokenRequest.mockRejectedValueOnce(mockError);
+
+      const first = useAuthStore.getState().refreshAccessToken();
+      const second = useAuthStore.getState().refreshAccessToken();
+
+      await expect(first).rejects.toThrow('Network request failed');
+      await expect(second).rejects.toThrow('Network request failed');
+
+      expect(mockedRefreshTokenRequest).toHaveBeenCalledTimes(1);
     });
 
     it('should logout when no refresh token is available', async () => {

--- a/src/stores/auth/store.tsx
+++ b/src/stores/auth/store.tsx
@@ -1,15 +1,19 @@
 import type { AxiosError } from 'axios';
+import * as SecureStore from 'expo-secure-store';
 import base64 from 'react-native-base64';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { logger } from '@/lib/logging';
+import { clearAllAppData, LOGOUT_PRESERVED_STORAGE_KEYS } from '@/lib/storage/clear-all-data';
 
 import { externalTokenRequest, loginRequest, refreshTokenRequest } from '../../lib/auth/api';
 import type { AuthResponse, AuthStatus, ExternalTokenCredentials, LoginCredentials } from '../../lib/auth/types';
 import { type ProfileModel } from '../../lib/auth/types';
 import { getAuth } from '../../lib/auth/utils';
 import { getItem, removeItem, setItem, zustandStorage } from '../../lib/storage';
+
+export const PENDING_SAML_STATE_KEY = 'pending_saml_state';
 
 // Helper function to determine if a refresh error is transient (network issues, rate limiting, etc.)
 // Transient errors should not force logout as they might resolve on retry
@@ -37,6 +41,8 @@ const isTransientRefreshError = (error: unknown): boolean => {
 
   return false;
 };
+
+let refreshAccessTokenInFlight: Promise<void> | null = null;
 
 interface AuthState {
   // Tokens
@@ -270,6 +276,30 @@ const useAuthStore = create<AuthState>()(
           });
         }
 
+        try {
+          await clearAllAppData({
+            resetStores: true,
+            clearStorage: true,
+            clearFilters: true,
+            clearSecure: false,
+            preserveStorageKeys: [...LOGOUT_PRESERVED_STORAGE_KEYS],
+          });
+        } catch (error) {
+          logger.warn({
+            message: 'Failed to clear app data during logout',
+            context: { error, reason },
+          });
+        }
+
+        try {
+          await SecureStore.deleteItemAsync(PENDING_SAML_STATE_KEY);
+        } catch (error) {
+          logger.warn({
+            message: 'Failed to clear pending SAML state during logout',
+            context: { error, reason },
+          });
+        }
+
         set({
           accessToken: null,
           refreshToken: null,
@@ -284,104 +314,118 @@ const useAuthStore = create<AuthState>()(
       },
 
       refreshAccessToken: async () => {
-        try {
-          const currentState = get();
-          const { refreshToken, userId } = currentState;
+        if (refreshAccessTokenInFlight) {
+          return refreshAccessTokenInFlight;
+        }
 
-          if (!refreshToken) {
-            logger.error({
-              message: 'No refresh token available for token refresh',
+        const refreshPromise = (async (): Promise<void> => {
+          try {
+            const currentState = get();
+            const { refreshToken, userId } = currentState;
+
+            if (!refreshToken) {
+              logger.error({
+                message: 'No refresh token available for token refresh',
+                context: { userId },
+              });
+              await get().logout('No refresh token available');
+              return;
+            }
+
+            // Check if refresh token is expired
+            if (currentState.isRefreshTokenExpired()) {
+              logger.error({
+                message: 'Refresh token expired, forcing logout',
+                context: {
+                  userId,
+                  refreshTokenObtainedAt: currentState.refreshTokenObtainedAt,
+                  currentTime: Date.now(),
+                },
+              });
+              await get().logout('Refresh token expired');
+              return;
+            }
+
+            logger.info({
+              message: 'Attempting to refresh access token',
               context: { userId },
             });
-            await get().logout('No refresh token available');
-            return;
-          }
 
-          // Check if refresh token is expired
-          if (currentState.isRefreshTokenExpired()) {
-            logger.error({
-              message: 'Refresh token expired, forcing logout',
+            const response = await refreshTokenRequest(refreshToken);
+            const now = Date.now();
+
+            // Read existing stored auth response to preserve refresh token if not provided
+            const existingAuthResponse = getItem<AuthResponse>('authResponse');
+
+            // Determine which refresh token and timestamp to use
+            const refreshTokenToUse = response.refresh_token || currentState.refreshToken || refreshToken;
+            const refreshTokenTimestamp = response.refresh_token ? now : currentState.refreshTokenObtainedAt || now;
+
+            // Update stored auth response with new tokens, preserving refresh token if not provided
+            const updatedAuthResponse: AuthResponse = {
+              access_token: response.access_token,
+              refresh_token: refreshTokenToUse,
+              id_token: response.id_token,
+              expires_in: response.expires_in,
+              token_type: response.token_type,
+              expiration_date: new Date(now + response.expires_in * 1000).toISOString(),
+              obtained_at: now,
+            };
+
+            setItem<AuthResponse>('authResponse', updatedAuthResponse);
+
+            set({
+              accessToken: response.access_token,
+              refreshToken: refreshTokenToUse,
+              accessTokenObtainedAt: now,
+              refreshTokenObtainedAt: refreshTokenTimestamp,
+              status: 'signedIn',
+              error: null,
+            });
+
+            logger.info({
+              message: 'Successfully refreshed access token',
               context: {
                 userId,
-                refreshTokenObtainedAt: currentState.refreshTokenObtainedAt,
-                currentTime: Date.now(),
+                newAccessTokenObtainedAt: now,
               },
             });
-            await get().logout('Refresh token expired');
-            return;
+          } catch (error) {
+            const currentState = get();
+
+            // Check if this is a transient error that might resolve on retry
+            const isTransientError = isTransientRefreshError(error);
+
+            if (isTransientError) {
+              logger.warn({
+                message: 'Transient token refresh error, not logging out',
+                context: {
+                  userId: currentState.userId,
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                },
+              });
+              // Re-throw the error to let the caller handle it (e.g., retry or use cached token)
+              throw error;
+            } else {
+              logger.error({
+                message: 'Failed to refresh access token, forcing logout',
+                context: {
+                  userId: currentState.userId,
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                },
+              });
+              // Only logout for permanent auth failures
+              await get().logout('Token refresh failed');
+            }
           }
+        })();
 
-          logger.info({
-            message: 'Attempting to refresh access token',
-            context: { userId },
-          });
+        refreshAccessTokenInFlight = refreshPromise;
 
-          const response = await refreshTokenRequest(refreshToken);
-          const now = Date.now();
-
-          // Read existing stored auth response to preserve refresh token if not provided
-          const existingAuthResponse = getItem<AuthResponse>('authResponse');
-
-          // Determine which refresh token and timestamp to use
-          const refreshTokenToUse = response.refresh_token || currentState.refreshToken || refreshToken;
-          const refreshTokenTimestamp = response.refresh_token ? now : currentState.refreshTokenObtainedAt || now;
-
-          // Update stored auth response with new tokens, preserving refresh token if not provided
-          const updatedAuthResponse: AuthResponse = {
-            access_token: response.access_token,
-            refresh_token: refreshTokenToUse,
-            id_token: response.id_token,
-            expires_in: response.expires_in,
-            token_type: response.token_type,
-            expiration_date: new Date(now + response.expires_in * 1000).toISOString(),
-            obtained_at: now,
-          };
-
-          setItem<AuthResponse>('authResponse', updatedAuthResponse);
-
-          set({
-            accessToken: response.access_token,
-            refreshToken: refreshTokenToUse,
-            accessTokenObtainedAt: now,
-            refreshTokenObtainedAt: refreshTokenTimestamp,
-            status: 'signedIn',
-            error: null,
-          });
-
-          logger.info({
-            message: 'Successfully refreshed access token',
-            context: {
-              userId,
-              newAccessTokenObtainedAt: now,
-            },
-          });
-        } catch (error) {
-          const currentState = get();
-
-          // Check if this is a transient error that might resolve on retry
-          const isTransientError = isTransientRefreshError(error);
-
-          if (isTransientError) {
-            logger.warn({
-              message: 'Transient token refresh error, not logging out',
-              context: {
-                userId: currentState.userId,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              },
-            });
-            // Re-throw the error to let the caller handle it (e.g., retry or use cached token)
-            throw error;
-          } else {
-            logger.error({
-              message: 'Failed to refresh access token, forcing logout',
-              context: {
-                userId: currentState.userId,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              },
-            });
-            // Only logout for permanent auth failures
-            await get().logout('Token refresh failed');
-          }
+        try {
+          await refreshPromise;
+        } finally {
+          refreshAccessTokenInFlight = null;
         }
       },
       hydrate: () => {

--- a/src/stores/calls/__tests__/check-in-store.test.ts
+++ b/src/stores/calls/__tests__/check-in-store.test.ts
@@ -168,5 +168,51 @@ describe('useCheckInStore', () => {
       expect(result.current.isLoadingStatuses).toBe(false);
       expect(result.current.statusError).toBeNull();
     });
+
+    it('should ignore a pending global overdue request after reset', async () => {
+      let resolveStatuses: (value: any) => void;
+      mockGetTimerStatuses.mockReturnValue(
+        new Promise((resolve) => {
+          resolveStatuses = resolve;
+        }) as any
+      );
+
+      await useCheckInStore.getState().fetchGlobalOverdueCount([{ CallId: '1', CheckInTimersEnabled: true }]);
+      jest.advanceTimersByTime(750);
+      await Promise.resolve();
+
+      useCheckInStore.getState().reset();
+
+      resolveStatuses!({ Data: [{ Status: 'Overdue' }] });
+      await Promise.resolve();
+
+      expect(useCheckInStore.getState().globalOverdueCount).toBe(0);
+    });
+  });
+
+  describe('fetchGlobalOverdueCount', () => {
+    it('should ignore an older request after a newer zero-timers fetch', async () => {
+      let resolveStatuses: (value: any) => void;
+      mockGetTimerStatuses.mockReturnValue(
+        new Promise((resolve) => {
+          resolveStatuses = resolve;
+        }) as any
+      );
+
+      await useCheckInStore.getState().fetchGlobalOverdueCount([{ CallId: '1', CheckInTimersEnabled: true }]);
+      jest.advanceTimersByTime(750);
+      await Promise.resolve();
+
+      useCheckInStore.setState({ globalOverdueCount: 7 });
+      await useCheckInStore.getState().fetchGlobalOverdueCount([]);
+      jest.advanceTimersByTime(750);
+      await Promise.resolve();
+      expect(useCheckInStore.getState().globalOverdueCount).toBe(0);
+
+      resolveStatuses!({ Data: [{ Status: 'Overdue' }] });
+      await Promise.resolve();
+
+      expect(useCheckInStore.getState().globalOverdueCount).toBe(0);
+    });
   });
 });

--- a/src/stores/calls/check-in-store.ts
+++ b/src/stores/calls/check-in-store.ts
@@ -22,6 +22,8 @@ const STATUS_SEVERITY: Record<string, number> = {
   Ok: 2,
 };
 
+let globalOverdueRequestGeneration = 0;
+
 interface CheckInState {
   timerStatuses: CheckInTimerStatusResultData[];
   resolvedTimers: ResolvedCheckInTimerResultData[];
@@ -166,6 +168,7 @@ export const useCheckInStore = create<CheckInState>((set, get) => ({
   },
 
   reset: () => {
+    globalOverdueRequestGeneration += 1;
     const interval = get()._pollingInterval;
     if (interval) {
       clearInterval(interval);
@@ -190,18 +193,25 @@ export const useCheckInStore = create<CheckInState>((set, get) => ({
   },
 
   fetchGlobalOverdueCount: async (calls: CallWithTimerFlag[]) => {
+    const generation = ++globalOverdueRequestGeneration;
     const existing = get()._globalOverdueDebounce;
     if (existing) {
       clearTimeout(existing);
     }
 
     const timer = setTimeout(() => {
+      if (generation !== globalOverdueRequestGeneration) {
+        return;
+      }
+
       set({ _globalOverdueDebounce: null });
 
       const executeFetch = async () => {
         const callsWithTimers = calls.filter((c) => c.CheckInTimersEnabled);
         if (callsWithTimers.length === 0) {
-          set({ globalOverdueCount: 0 });
+          if (generation === globalOverdueRequestGeneration) {
+            set({ globalOverdueCount: 0 });
+          }
           return;
         }
 
@@ -218,7 +228,9 @@ export const useCheckInStore = create<CheckInState>((set, get) => ({
           })
         );
 
-        set({ globalOverdueCount: counts.reduce((acc, n) => acc + n, 0) });
+        if (generation === globalOverdueRequestGeneration) {
+          set({ globalOverdueCount: counts.reduce((acc, n) => acc + n, 0) });
+        }
       };
 
       void executeFetch();

--- a/src/stores/calls/check-in-store.ts
+++ b/src/stores/calls/check-in-store.ts
@@ -32,6 +32,7 @@ interface CheckInState {
   statusError: string | null;
   checkInError: string | null;
   _pollingInterval: ReturnType<typeof setInterval> | null;
+  _globalOverdueDebounce: ReturnType<typeof setTimeout> | null;
   /** Aggregate overdue+warning count across all active calls — used by the home page summary. */
   globalOverdueCount: number;
 
@@ -56,6 +57,7 @@ export const useCheckInStore = create<CheckInState>((set, get) => ({
   statusError: null,
   checkInError: null,
   _pollingInterval: null,
+  _globalOverdueDebounce: null,
   globalOverdueCount: 0,
 
   fetchTimerStatuses: async (callId: number) => {
@@ -168,6 +170,10 @@ export const useCheckInStore = create<CheckInState>((set, get) => ({
     if (interval) {
       clearInterval(interval);
     }
+    const debounce = get()._globalOverdueDebounce;
+    if (debounce) {
+      clearTimeout(debounce);
+    }
     set({
       timerStatuses: [],
       resolvedTimers: [],
@@ -178,30 +184,46 @@ export const useCheckInStore = create<CheckInState>((set, get) => ({
       statusError: null,
       checkInError: null,
       _pollingInterval: null,
+      _globalOverdueDebounce: null,
       globalOverdueCount: 0,
     });
   },
 
   fetchGlobalOverdueCount: async (calls: CallWithTimerFlag[]) => {
-    const callsWithTimers = calls.filter((c) => c.CheckInTimersEnabled);
-    if (callsWithTimers.length === 0) {
-      set({ globalOverdueCount: 0 });
-      return;
+    const existing = get()._globalOverdueDebounce;
+    if (existing) {
+      clearTimeout(existing);
     }
 
-    const counts = await Promise.all(
-      callsWithTimers.map(async (call) => {
-        try {
-          const callId = parseInt(call.CallId, 10);
-          const result = (await getTimerStatuses(callId)) as ApiResponse<CheckInTimerStatusResultData[]>;
-          const statuses = result.Data ?? [];
-          return statuses.filter((s) => s.Status === 'Overdue' || s.Status === 'Warning').length;
-        } catch {
-          return 0;
-        }
-      })
-    );
+    const timer = setTimeout(() => {
+      set({ _globalOverdueDebounce: null });
 
-    set({ globalOverdueCount: counts.reduce((acc, n) => acc + n, 0) });
+      const executeFetch = async () => {
+        const callsWithTimers = calls.filter((c) => c.CheckInTimersEnabled);
+        if (callsWithTimers.length === 0) {
+          set({ globalOverdueCount: 0 });
+          return;
+        }
+
+        const counts = await Promise.all(
+          callsWithTimers.map(async (call) => {
+            try {
+              const callId = parseInt(call.CallId, 10);
+              const result = (await getTimerStatuses(callId)) as ApiResponse<CheckInTimerStatusResultData[]>;
+              const statuses = result.Data ?? [];
+              return statuses.filter((s) => s.Status === 'Overdue' || s.Status === 'Warning').length;
+            } catch {
+              return 0;
+            }
+          })
+        );
+
+        set({ globalOverdueCount: counts.reduce((acc, n) => acc + n, 0) });
+      };
+
+      void executeFetch();
+    }, 750);
+
+    set({ _globalOverdueDebounce: timer });
   },
 }));

--- a/src/stores/offline-queue/__tests__/store.test.ts
+++ b/src/stores/offline-queue/__tests__/store.test.ts
@@ -3,7 +3,7 @@ import { useOfflineQueueStore } from '@/stores/offline-queue/store';
 
 // Mock NetInfo
 jest.mock('@react-native-community/netinfo', () => ({
-  addEventListener: jest.fn(),
+  addEventListener: jest.fn(() => jest.fn()),
   fetch: jest.fn(() =>
     Promise.resolve({
       isConnected: true,
@@ -374,8 +374,7 @@ describe('OfflineQueueStore', () => {
   });
 
   describe('network state management', () => {
-    it('should update network state', () => {
-      const store = useOfflineQueueStore.getState();
+    it('should update network state', () => {const store = useOfflineQueueStore.getState();
       
       store._setNetworkState(false, false);
 
@@ -386,12 +385,99 @@ describe('OfflineQueueStore', () => {
 
     it('should update processing state', () => {
       const store = useOfflineQueueStore.getState();
-      
+
       store._setProcessing(true, 'event-123');
 
       const state = useOfflineQueueStore.getState();
       expect(state.isProcessing).toBe(true);
       expect(state.processingEventId).toBe('event-123');
+    });
+  });
+
+  describe('network listener lifecycle', () => {
+    afterEach(() => {
+      useOfflineQueueStore.getState().teardownNetworkListener();
+    });
+
+    it('should register the network listener only once', () => {
+      const NetInfo = require('@react-native-community/netinfo');
+      const store = useOfflineQueueStore.getState();
+
+      store.initializeNetworkListener();
+      store.initializeNetworkListener();
+
+      expect(NetInfo.addEventListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unsubscribe and allow re-registration after teardown', () => {
+      const NetInfo = require('@react-native-community/netinfo');
+      const unsubscribeMock = jest.fn();
+      NetInfo.addEventListener.mockReturnValueOnce(unsubscribeMock);
+      const store = useOfflineQueueStore.getState();
+
+      store.initializeNetworkListener();
+      store.teardownNetworkListener();
+
+      expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+
+      store.initializeNetworkListener();
+      expect(NetInfo.addEventListener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('purgeStaleFailedEvents', () => {
+    const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+
+    const addFailedEvent = (lastAttemptAt: number): string => {
+      const store = useOfflineQueueStore.getState();
+      const eventId = store.addEvent(QueuedEventType.UNIT_STATUS, { test: 'data' });
+      store.updateEventStatus(eventId, QueuedEventStatus.FAILED, 'error');
+      store.updateEventStatus(eventId, QueuedEventStatus.FAILED, 'error');
+      store.updateEventStatus(eventId, QueuedEventStatus.FAILED, 'error');
+      useOfflineQueueStore.setState((state) => ({
+        queuedEvents: state.queuedEvents.map((event) => (event.id === eventId ? { ...event, lastAttemptAt } : event)),
+      }));
+      return eventId;
+    };
+
+    it('should remove exhausted failed events older than 7 days', () => {
+      const oldEventId = addFailedEvent(Date.now() - EIGHT_DAYS_MS);
+
+      useOfflineQueueStore.getState().purgeStaleFailedEvents();
+
+      const state = useOfflineQueueStore.getState();
+      expect(state.queuedEvents.find((event) => event.id === oldEventId)).toBeUndefined();
+    });
+
+    it('should keep recent exhausted failed events', () => {
+      const recentEventId = addFailedEvent(Date.now());
+
+      useOfflineQueueStore.getState().purgeStaleFailedEvents();
+
+      const state = useOfflineQueueStore.getState();
+      expect(state.queuedEvents.find((event) => event.id === recentEventId)).toBeDefined();
+    });
+
+    it('should keep pending events regardless of age', () => {
+      const store = useOfflineQueueStore.getState();
+      const eventId = store.addEvent(QueuedEventType.UNIT_STATUS, { test: 'data' });
+      useOfflineQueueStore.setState((state) => ({
+        queuedEvents: state.queuedEvents.map((event) => (event.id === eventId ? { ...event, createdAt: Date.now() - EIGHT_DAYS_MS } : event)),
+      }));
+
+      useOfflineQueueStore.getState().purgeStaleFailedEvents();
+
+      expect(useOfflineQueueStore.getState().queuedEvents).toHaveLength(1);
+    });
+
+    it('should purge stale failed events when adding a new event', () => {
+      addFailedEvent(Date.now() - EIGHT_DAYS_MS);
+
+      useOfflineQueueStore.getState().addEvent(QueuedEventType.UNIT_STATUS, { test: 'new' });
+
+      const state = useOfflineQueueStore.getState();
+      expect(state.queuedEvents).toHaveLength(1);
+      expect(state.queuedEvents[0]?.status).toBe(QueuedEventStatus.PENDING);
     });
   });
 });

--- a/src/stores/offline-queue/__tests__/store.test.ts
+++ b/src/stores/offline-queue/__tests__/store.test.ts
@@ -1,4 +1,5 @@
-import { QueuedEventStatus, QueuedEventType } from '@/models/offline-queue/queued-event';
+import { logger } from '@/lib/logging';
+import { type QueuedEvent, QueuedEventStatus, QueuedEventType } from '@/models/offline-queue/queued-event';
 import { useOfflineQueueStore } from '@/stores/offline-queue/store';
 
 // Mock NetInfo
@@ -39,6 +40,7 @@ jest.mock('@/utils/id-generator', () => ({
 }));
 
 const mockGenerateEventId = require('@/utils/id-generator').generateEventId as jest.MockedFunction<() => string>;
+const mockLogger = logger as jest.Mocked<typeof logger>;
 
 describe('OfflineQueueStore', () => {
   let eventIdCounter = 0;
@@ -478,6 +480,61 @@ describe('OfflineQueueStore', () => {
       const state = useOfflineQueueStore.getState();
       expect(state.queuedEvents).toHaveLength(1);
       expect(state.queuedEvents[0]?.status).toBe(QueuedEventStatus.PENDING);
+    });
+
+    it('should warn with separate counts when the queue cap drops only dead letters', () => {
+      const now = Date.now();
+      const deadLetters: QueuedEvent[] = Array.from({ length: 501 }, (_, index) => ({
+        id: `dead-letter-${index}`,
+        type: QueuedEventType.UNIT_STATUS,
+        status: QueuedEventStatus.FAILED,
+        data: {},
+        retryCount: 3,
+        maxRetries: 3,
+        createdAt: now,
+        lastAttemptAt: now,
+      }));
+      useOfflineQueueStore.setState({ queuedEvents: deadLetters });
+
+      useOfflineQueueStore.getState().purgeStaleFailedEvents();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith({
+        message: 'Offline queue size cap reached, dropped oldest events',
+        context: { droppedPending: 0, droppedDeadLetters: 1 },
+      });
+      expect(mockLogger.error).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Offline queue size cap reached, dropped oldest events' }));
+    });
+
+    it('should log an error when the queue cap drops pending events', () => {
+      const now = Date.now();
+      const deadLetter: QueuedEvent = {
+        id: 'dead-letter',
+        type: QueuedEventType.UNIT_STATUS,
+        status: QueuedEventStatus.FAILED,
+        data: {},
+        retryCount: 3,
+        maxRetries: 3,
+        createdAt: now,
+        lastAttemptAt: now,
+      };
+      const pending: QueuedEvent[] = Array.from({ length: 501 }, (_, index) => ({
+        id: `pending-${index}`,
+        type: QueuedEventType.UNIT_STATUS,
+        status: QueuedEventStatus.PENDING,
+        data: {},
+        retryCount: 0,
+        maxRetries: 3,
+        createdAt: index,
+      }));
+      useOfflineQueueStore.setState({ queuedEvents: [deadLetter, ...pending] });
+
+      useOfflineQueueStore.getState().purgeStaleFailedEvents();
+
+      expect(mockLogger.error).toHaveBeenCalledWith({
+        message: 'Offline queue size cap reached, dropped oldest events',
+        context: { droppedPending: 1, droppedDeadLetters: 1 },
+      });
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Offline queue size cap reached, dropped oldest events' }));
     });
   });
 });

--- a/src/stores/offline-queue/store.ts
+++ b/src/stores/offline-queue/store.ts
@@ -80,11 +80,19 @@ const pruneEvents = (events: QueuedEvent[]): { events: QueuedEvent[]; purgedStal
       const extra = remaining.sort((a, b) => a.createdAt - b.createdAt).slice(0, overflow - toDrop.size);
       extra.forEach((event) => toDrop.add(event.id));
     }
+    const droppedEvents = pruned.filter((event) => toDrop.has(event.id));
+    const droppedDeadLetters = droppedEvents.filter(isExhaustedFailedEvent).length;
+    const droppedPending = droppedEvents.length - droppedDeadLetters;
     pruned = pruned.filter((event) => !toDrop.has(event.id));
-    logger.warn({
+    const logEntry = {
       message: 'Offline queue size cap reached, dropped oldest events',
-      context: { dropped: toDrop.size },
-    });
+      context: { droppedPending, droppedDeadLetters },
+    };
+    if (droppedPending > 0) {
+      logger.error(logEntry);
+    } else {
+      logger.warn(logEntry);
+    }
   }
 
   return { events: pruned, purgedStale };

--- a/src/stores/offline-queue/store.ts
+++ b/src/stores/offline-queue/store.ts
@@ -24,6 +24,7 @@ interface OfflineQueueState {
 
   // Actions
   initializeNetworkListener: () => void;
+  teardownNetworkListener: () => void;
   addEvent: (type: QueuedEventType, data: Record<string, any>, maxRetries?: number) => string;
   updateEventStatus: (eventId: string, status: QueuedEventStatus, error?: string) => void;
   removeEvent: (eventId: string) => void;
@@ -35,6 +36,7 @@ interface OfflineQueueState {
   clearAllEvents: () => void;
   retryEvent: (eventId: string) => void;
   retryAllFailedEvents: () => void;
+  purgeStaleFailedEvents: () => void;
 
   // Internal actions
   _setNetworkState: (isConnected: boolean, isReachable: boolean) => void;
@@ -43,6 +45,50 @@ interface OfflineQueueState {
 
 const DEFAULT_MAX_RETRIES = 3;
 const RETRY_DELAY_BASE = 1000; // 1 second base delay
+const FAILED_EVENT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // Purge dead-letter events after 7 days
+const MAX_QUEUE_SIZE = 500; // Cap total queue size, dropping oldest dead-letter events first
+
+let networkUnsubscribe: (() => void) | null = null;
+
+const isExhaustedFailedEvent = (event: QueuedEvent): boolean => event.status === QueuedEventStatus.FAILED && event.retryCount >= event.maxRetries;
+
+const isStaleFailedEvent = (event: QueuedEvent, now: number): boolean => {
+  if (!isExhaustedFailedEvent(event)) return false;
+  const referenceTime = event.lastAttemptAt ?? event.createdAt;
+  return now - referenceTime > FAILED_EVENT_TTL_MS;
+};
+
+const pruneEvents = (events: QueuedEvent[]): { events: QueuedEvent[]; purgedStale: number } => {
+  const now = Date.now();
+  let purgedStale = 0;
+  let pruned = events.filter((event) => {
+    if (isStaleFailedEvent(event, now)) {
+      purgedStale++;
+      return false;
+    }
+    return true;
+  });
+
+  // Enforce queue size cap: drop oldest dead-letter events first
+  if (pruned.length > MAX_QUEUE_SIZE) {
+    const overflow = pruned.length - MAX_QUEUE_SIZE;
+    const deadLetters = pruned.filter(isExhaustedFailedEvent).sort((a, b) => (a.lastAttemptAt ?? a.createdAt) - (b.lastAttemptAt ?? b.createdAt));
+    const toDrop = new Set(deadLetters.slice(0, overflow).map((event) => event.id));
+    if (toDrop.size < overflow) {
+      // Not enough dead letters: fall back to dropping oldest events overall
+      const remaining = pruned.filter((event) => !toDrop.has(event.id));
+      const extra = remaining.sort((a, b) => a.createdAt - b.createdAt).slice(0, overflow - toDrop.size);
+      extra.forEach((event) => toDrop.add(event.id));
+    }
+    pruned = pruned.filter((event) => !toDrop.has(event.id));
+    logger.warn({
+      message: 'Offline queue size cap reached, dropped oldest events',
+      context: { dropped: toDrop.size },
+    });
+  }
+
+  return { events: pruned, purgedStale };
+};
 
 export const useOfflineQueueStore = create<OfflineQueueState>()(
   persist(
@@ -59,7 +105,14 @@ export const useOfflineQueueStore = create<OfflineQueueState>()(
 
       // Initialize network state listener
       initializeNetworkListener: () => {
-        NetInfo.addEventListener((state: NetInfoState) => {
+        if (networkUnsubscribe) {
+          logger.debug({
+            message: 'Network listener already registered, skipping',
+          });
+          return;
+        }
+
+        networkUnsubscribe = NetInfo.addEventListener((state: NetInfoState) => {
           const isConnected = state.isConnected ?? false;
           const isReachable = state.isInternetReachable ?? false;
 
@@ -84,6 +137,18 @@ export const useOfflineQueueStore = create<OfflineQueueState>()(
         });
       },
 
+      // Remove the network state listener
+      teardownNetworkListener: () => {
+        if (networkUnsubscribe) {
+          networkUnsubscribe();
+          networkUnsubscribe = null;
+
+          logger.info({
+            message: 'Network listener torn down',
+          });
+        }
+      },
+
       // Add new event to queue
       addEvent: (type: QueuedEventType, data: Record<string, any>, maxRetries = DEFAULT_MAX_RETRIES) => {
         const eventId = generateEventId();
@@ -99,10 +164,19 @@ export const useOfflineQueueStore = create<OfflineQueueState>()(
           createdAt: now,
         };
 
-        set((state) => ({
-          queuedEvents: [...state.queuedEvents, event],
-          totalEvents: state.totalEvents + 1,
-        }));
+        set((state) => {
+          const { events, purgedStale } = pruneEvents(state.queuedEvents);
+          if (purgedStale > 0) {
+            logger.info({
+              message: 'Purged stale failed events from offline queue',
+              context: { purgedStale },
+            });
+          }
+          return {
+            queuedEvents: [...events, event],
+            totalEvents: state.totalEvents + 1,
+          };
+        });
 
         logger.info({
           message: 'Event added to offline queue',
@@ -253,6 +327,21 @@ export const useOfflineQueueStore = create<OfflineQueueState>()(
         });
       },
 
+      // Purge dead-letter events older than the TTL and enforce queue size cap
+      purgeStaleFailedEvents: () => {
+        set((state) => {
+          const { events, purgedStale } = pruneEvents(state.queuedEvents);
+          if (purgedStale > 0 || events.length !== state.queuedEvents.length) {
+            logger.info({
+              message: 'Purged events from offline queue',
+              context: { purgedStale, removed: state.queuedEvents.length - events.length },
+            });
+            return { queuedEvents: events };
+          }
+          return state;
+        });
+      },
+
       // Internal actions
       _setNetworkState: (isConnected: boolean, isReachable: boolean) => {
         set({ isConnected, isNetworkReachable: isReachable });
@@ -275,6 +364,10 @@ export const useOfflineQueueStore = create<OfflineQueueState>()(
         failedEvents: state.failedEvents,
         completedEvents: state.completedEvents,
       }),
+      onRehydrateStorage: () => (state) => {
+        // Purge stale dead-letter events once the persisted queue has been loaded
+        state?.purgeStaleFailedEvents();
+      },
     }
   )
 );

--- a/src/stores/signalr/__tests__/signalr-store.test.ts
+++ b/src/stores/signalr/__tests__/signalr-store.test.ts
@@ -22,6 +22,7 @@ jest.mock('@/services/signalr.service', () => {
     disconnectFromHub: jest.fn().mockResolvedValue(undefined),
     invoke: jest.fn().mockResolvedValue(undefined),
     on: jest.fn(),
+    off: jest.fn(),
     connectToHub: jest.fn().mockResolvedValue(undefined),
     disconnectAll: jest.fn().mockResolvedValue(undefined),
   };
@@ -199,6 +200,49 @@ describe('useSignalRStore', () => {
   });
 
   describe('disconnectUpdateHub', () => {
+    it('unsubscribes update hub handlers using their registered references', async () => {
+      const { result } = renderHook(() => useSignalRStore());
+
+      await act(async () => {
+        await result.current.connectUpdateHub();
+      });
+
+      const registrations = (signalRService.on as jest.Mock).mock.calls.filter(([event]) => event !== 'onPersonnelLocationUpdated' && event !== 'onUnitLocationUpdated' && event !== 'onGeolocationConnect');
+
+      await act(async () => {
+        await result.current.disconnectUpdateHub();
+      });
+
+      expect(registrations).toHaveLength(10);
+      registrations.forEach(([event, handler]) => {
+        expect(signalRService.off).toHaveBeenCalledWith(event, handler);
+      });
+    });
+
+    it('contains update handler errors and logs them', async () => {
+      const handlerError = new Error('handler failed');
+      const { result } = renderHook(() => useSignalRStore());
+
+      await act(async () => {
+        await result.current.connectUpdateHub();
+      });
+
+      const personnelStatusHandler = (signalRService.on as jest.Mock).mock.calls.find(([event]) => event === 'personnelStatusUpdated')?.[1];
+      (logger.info as jest.Mock).mockImplementationOnce(() => {
+        throw handlerError;
+      });
+
+      expect(() => personnelStatusHandler({ UserId: 'user-1' })).not.toThrow();
+      expect(logger.error).toHaveBeenCalledWith({
+        message: 'Failed to handle SignalR event: personnelStatusUpdated',
+        context: { error: handlerError },
+      });
+
+      await act(async () => {
+        await result.current.disconnectUpdateHub();
+      });
+    });
+
     it('should disconnect from update hub successfully', async () => {
       const { result } = renderHook(() => useSignalRStore());
 
@@ -213,15 +257,20 @@ describe('useSignalRStore', () => {
 
     it('should handle disconnect errors', async () => {
       const disconnectError = new Error('Disconnect failed');
-      (signalRService.disconnectFromHub as jest.Mock).mockRejectedValue(disconnectError);
-
       const { result } = renderHook(() => useSignalRStore());
+
+      await act(async () => {
+        await result.current.connectUpdateHub();
+      });
+
+      (signalRService.disconnectFromHub as jest.Mock).mockRejectedValue(disconnectError);
 
       await act(async () => {
         await result.current.disconnectUpdateHub();
       });
 
       expect(result.current.error).toEqual(disconnectError);
+      expect(signalRService.off).toHaveBeenCalledTimes(10);
       expect(logger.error).toHaveBeenCalledWith({
         message: 'Failed to disconnect from SignalR hubs',
         context: { error: disconnectError },

--- a/src/stores/signalr/signalr-store.ts
+++ b/src/stores/signalr/signalr-store.ts
@@ -23,114 +23,196 @@ interface SignalRState {
   disconnectGeolocationHub: () => Promise<void>;
 }
 
+type SignalRHandler = (message: unknown) => void;
+
 export const useSignalRStore = create<SignalRState>((set, get) => {
-  signalRService.on('personnelStatusUpdated', (message) => {
-    logger.info({
-      message: 'personnelStatusUpdated',
-      context: { message },
-    });
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const createSafeHandler = (event: string, handler: SignalRHandler): SignalRHandler => {
+    return (message) => {
+      try {
+        handler(message);
+      } catch (error) {
+        logger.error({
+          message: `Failed to handle SignalR event: ${event}`,
+          context: { error },
+        });
+      }
+    };
+  };
 
-  signalRService.on('personnelStaffingUpdated', (message) => {
-    logger.info({
-      message: 'personnelStaffingUpdated',
-      context: { message },
-    });
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const updateHubHandlers = new Map<string, SignalRHandler>([
+    [
+      'personnelStatusUpdated',
+      createSafeHandler('personnelStatusUpdated', (message) => {
+        logger.info({
+          message: 'personnelStatusUpdated',
+          context: { message },
+        });
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'personnelStaffingUpdated',
+      createSafeHandler('personnelStaffingUpdated', (message) => {
+        logger.info({
+          message: 'personnelStaffingUpdated',
+          context: { message },
+        });
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'unitStatusUpdated',
+      createSafeHandler('unitStatusUpdated', (message) => {
+        logger.info({
+          message: 'unitStatusUpdated',
+          context: { message },
+        });
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'callsUpdated',
+      createSafeHandler('callsUpdated', (message) => {
+        const now = Date.now();
 
-  signalRService.on('unitStatusUpdated', (message) => {
-    logger.info({
-      message: 'unitStatusUpdated',
-      context: { message },
-    });
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+        logger.info({
+          message: 'callsUpdated',
+          context: { message, now },
+        });
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: now });
+      }),
+    ],
+    [
+      'callAdded',
+      createSafeHandler('callAdded', (message) => {
+        logger.info({
+          message: 'callAdded',
+          context: { message },
+        });
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'callClosed',
+      createSafeHandler('callClosed', (message) => {
+        logger.info({
+          message: 'callClosed',
+          context: { message },
+        });
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'weatherAlertReceived',
+      createSafeHandler('weatherAlertReceived', (message) => {
+        logger.info({
+          message: 'weatherAlertReceived',
+          context: { message },
+        });
+        const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
+        if (alertId) {
+          useWeatherAlertsStore.getState().handleAlertReceived(alertId);
+        }
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'weatherAlertUpdated',
+      createSafeHandler('weatherAlertUpdated', (message) => {
+        logger.info({
+          message: 'weatherAlertUpdated',
+          context: { message },
+        });
+        const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
+        if (alertId) {
+          useWeatherAlertsStore.getState().handleAlertUpdated(alertId);
+        }
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'weatherAlertExpired',
+      createSafeHandler('weatherAlertExpired', (message) => {
+        logger.info({
+          message: 'weatherAlertExpired',
+          context: { message },
+        });
+        const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
+        if (alertId) {
+          useWeatherAlertsStore.getState().handleAlertExpired(alertId);
+        }
+        set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'onConnected',
+      createSafeHandler('onConnected', () => {
+        logger.info({
+          message: 'Connected to update SignalR hub',
+        });
+        set({ isUpdateHubConnected: true, error: null });
+      }),
+    ],
+  ]);
 
-  signalRService.on('callsUpdated', (message) => {
-    const now = Date.now();
+  const geolocationHubHandlers = new Map<string, SignalRHandler>([
+    [
+      'onPersonnelLocationUpdated',
+      createSafeHandler('onPersonnelLocationUpdated', (message) => {
+        set({ lastGeolocationMessage: message, lastGeolocationTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'onUnitLocationUpdated',
+      createSafeHandler('onUnitLocationUpdated', (message) => {
+        set({ lastGeolocationMessage: message, lastGeolocationTimestamp: Date.now() });
+      }),
+    ],
+    [
+      'onGeolocationConnect',
+      createSafeHandler('onGeolocationConnect', () => {
+        logger.info({
+          message: 'Connected to geolocation SignalR hub',
+        });
+        set({ isGeolocationHubConnected: true, error: null });
+      }),
+    ],
+  ]);
 
-    logger.info({
-      message: 'callsUpdated',
-      context: { message, now },
-    });
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: now });
-  });
+  let updateHubHandlersSubscribed = false;
+  let geolocationHubHandlersSubscribed = false;
 
-  signalRService.on('callAdded', (message) => {
-    logger.info({
-      message: 'callAdded',
-      context: { message },
-    });
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const subscribeHandlers = (handlers: Map<string, SignalRHandler>) => {
+    handlers.forEach((handler, event) => signalRService.on(event, handler));
+  };
 
-  signalRService.on('callClosed', (message) => {
-    logger.info({
-      message: 'callClosed',
-      context: { message },
-    });
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const unsubscribeHandlers = (handlers: Map<string, SignalRHandler>) => {
+    handlers.forEach((handler, event) => signalRService.off(event, handler));
+  };
 
-  signalRService.on('weatherAlertReceived', (message) => {
-    logger.info({
-      message: 'weatherAlertReceived',
-      context: { message },
-    });
-    const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
-    if (alertId) {
-      useWeatherAlertsStore.getState().handleAlertReceived(alertId);
-    }
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const subscribeUpdateHubHandlers = () => {
+    if (updateHubHandlersSubscribed) return;
+    subscribeHandlers(updateHubHandlers);
+    updateHubHandlersSubscribed = true;
+  };
 
-  signalRService.on('weatherAlertUpdated', (message) => {
-    logger.info({
-      message: 'weatherAlertUpdated',
-      context: { message },
-    });
-    const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
-    if (alertId) {
-      useWeatherAlertsStore.getState().handleAlertUpdated(alertId);
-    }
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const unsubscribeUpdateHubHandlers = () => {
+    if (!updateHubHandlersSubscribed) return;
+    unsubscribeHandlers(updateHubHandlers);
+    updateHubHandlersSubscribed = false;
+  };
 
-  signalRService.on('weatherAlertExpired', (message) => {
-    logger.info({
-      message: 'weatherAlertExpired',
-      context: { message },
-    });
-    const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
-    if (alertId) {
-      useWeatherAlertsStore.getState().handleAlertExpired(alertId);
-    }
-    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
-  });
+  const subscribeGeolocationHubHandlers = () => {
+    if (geolocationHubHandlersSubscribed) return;
+    subscribeHandlers(geolocationHubHandlers);
+    geolocationHubHandlersSubscribed = true;
+  };
 
-  signalRService.on('onConnected', () => {
-    logger.info({
-      message: 'Connected to update SignalR hub',
-    });
-    set({ isUpdateHubConnected: true, error: null });
-  });
-
-  signalRService.on('onPersonnelLocationUpdated', (message) => {
-    set({ lastGeolocationMessage: message, lastGeolocationTimestamp: Date.now() });
-  });
-
-  signalRService.on('onUnitLocationUpdated', (message) => {
-    set({ lastGeolocationMessage: message, lastGeolocationTimestamp: Date.now() });
-  });
-
-  signalRService.on('onGeolocationConnect', () => {
-    logger.info({
-      message: 'Connected to geolocation SignalR hub',
-    });
-    set({ isGeolocationHubConnected: true, error: null });
-  });
+  const unsubscribeGeolocationHubHandlers = () => {
+    if (!geolocationHubHandlersSubscribed) return;
+    unsubscribeHandlers(geolocationHubHandlers);
+    geolocationHubHandlersSubscribed = false;
+  };
 
   return {
     isUpdateHubConnected: false,
@@ -162,6 +244,7 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
         }
 
         // Connect to the eventing hub
+        subscribeUpdateHubHandlers();
         await signalRService.connectToHubWithEventingUrl({
           name: Env.CHANNEL_HUB_NAME,
           eventingUrl: eventingUrl,
@@ -187,13 +270,13 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
           message: 'Failed to connect to SignalR hubs',
           context: { error: err },
         });
+        unsubscribeUpdateHubHandlers();
         set({ error: err });
       }
     },
     disconnectUpdateHub: async () => {
       try {
         await signalRService.disconnectFromHub(Env.CHANNEL_HUB_NAME);
-        set({ isUpdateHubConnected: false, lastUpdateMessage: null });
       } catch (error) {
         const err = error instanceof Error ? error : new Error('Unknown error occurred');
         logger.error({
@@ -201,6 +284,9 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
           context: { error: err },
         });
         set({ error: err });
+      } finally {
+        unsubscribeUpdateHubHandlers();
+        set({ isUpdateHubConnected: false, lastUpdateMessage: null });
       }
     },
     connectGeolocationHub: async () => {
@@ -225,6 +311,7 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
         }
 
         // Connect to the geolocation hub
+        subscribeGeolocationHubHandlers();
         await signalRService.connectToHubWithEventingUrl({
           name: Env.REALTIME_GEO_HUB_NAME,
           eventingUrl: eventingUrl,
@@ -237,13 +324,13 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
           message: 'Failed to connect to SignalR hubs',
           context: { error: err },
         });
+        unsubscribeGeolocationHubHandlers();
         set({ error: err });
       }
     },
     disconnectGeolocationHub: async () => {
       try {
         await signalRService.disconnectFromHub(Env.REALTIME_GEO_HUB_NAME);
-        set({ isGeolocationHubConnected: false, lastGeolocationMessage: null });
       } catch (error) {
         const err = error instanceof Error ? error : new Error('Unknown error occurred');
         logger.error({
@@ -251,6 +338,9 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
           context: { error: err },
         });
         set({ error: err });
+      } finally {
+        unsubscribeGeolocationHubHandlers();
+        set({ isGeolocationHubConnected: false, lastGeolocationMessage: null });
       }
     },
   };

--- a/src/stores/signalr/signalr-store.ts
+++ b/src/stores/signalr/signalr-store.ts
@@ -23,234 +23,235 @@ interface SignalRState {
   disconnectGeolocationHub: () => Promise<void>;
 }
 
-export const useSignalRStore = create<SignalRState>((set, get) => ({
-  isUpdateHubConnected: false,
-  lastUpdateMessage: null,
-  lastUpdateTimestamp: 0,
-  isGeolocationHubConnected: false,
-  lastGeolocationMessage: null,
-  lastGeolocationTimestamp: 0,
-  error: null,
-  connectUpdateHub: async () => {
-    try {
-      if (get().isUpdateHubConnected) {
-        return;
-      }
+export const useSignalRStore = create<SignalRState>((set, get) => {
+  signalRService.on('personnelStatusUpdated', (message) => {
+    logger.info({
+      message: 'personnelStatusUpdated',
+      context: { message },
+    });
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
 
-      set({ isUpdateHubConnected: false, error: null });
+  signalRService.on('personnelStaffingUpdated', (message) => {
+    logger.info({
+      message: 'personnelStaffingUpdated',
+      context: { message },
+    });
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
 
-      // Get the eventing URL from the core store config
-      const coreState = useCoreStore.getState();
-      const eventingUrl = coreState.config?.EventingUrl;
+  signalRService.on('unitStatusUpdated', (message) => {
+    logger.info({
+      message: 'unitStatusUpdated',
+      context: { message },
+    });
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
 
-      if (!eventingUrl) {
-        const errorMessage = 'EventingUrl not available in config. Please ensure config is loaded first.';
+  signalRService.on('callsUpdated', (message) => {
+    const now = Date.now();
+
+    logger.info({
+      message: 'callsUpdated',
+      context: { message, now },
+    });
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: now });
+  });
+
+  signalRService.on('callAdded', (message) => {
+    logger.info({
+      message: 'callAdded',
+      context: { message },
+    });
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
+
+  signalRService.on('callClosed', (message) => {
+    logger.info({
+      message: 'callClosed',
+      context: { message },
+    });
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
+
+  signalRService.on('weatherAlertReceived', (message) => {
+    logger.info({
+      message: 'weatherAlertReceived',
+      context: { message },
+    });
+    const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
+    if (alertId) {
+      useWeatherAlertsStore.getState().handleAlertReceived(alertId);
+    }
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
+
+  signalRService.on('weatherAlertUpdated', (message) => {
+    logger.info({
+      message: 'weatherAlertUpdated',
+      context: { message },
+    });
+    const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
+    if (alertId) {
+      useWeatherAlertsStore.getState().handleAlertUpdated(alertId);
+    }
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
+
+  signalRService.on('weatherAlertExpired', (message) => {
+    logger.info({
+      message: 'weatherAlertExpired',
+      context: { message },
+    });
+    const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
+    if (alertId) {
+      useWeatherAlertsStore.getState().handleAlertExpired(alertId);
+    }
+    set({ lastUpdateMessage: message, lastUpdateTimestamp: Date.now() });
+  });
+
+  signalRService.on('onConnected', () => {
+    logger.info({
+      message: 'Connected to update SignalR hub',
+    });
+    set({ isUpdateHubConnected: true, error: null });
+  });
+
+  signalRService.on('onPersonnelLocationUpdated', (message) => {
+    set({ lastGeolocationMessage: message, lastGeolocationTimestamp: Date.now() });
+  });
+
+  signalRService.on('onUnitLocationUpdated', (message) => {
+    set({ lastGeolocationMessage: message, lastGeolocationTimestamp: Date.now() });
+  });
+
+  signalRService.on('onGeolocationConnect', () => {
+    logger.info({
+      message: 'Connected to geolocation SignalR hub',
+    });
+    set({ isGeolocationHubConnected: true, error: null });
+  });
+
+  return {
+    isUpdateHubConnected: false,
+    lastUpdateMessage: null,
+    lastUpdateTimestamp: 0,
+    isGeolocationHubConnected: false,
+    lastGeolocationMessage: null,
+    lastGeolocationTimestamp: 0,
+    error: null,
+    connectUpdateHub: async () => {
+      try {
+        if (get().isUpdateHubConnected) {
+          return;
+        }
+
+        set({ isUpdateHubConnected: false, error: null });
+
+        // Get the eventing URL from the core store config
+        const coreState = useCoreStore.getState();
+        const eventingUrl = coreState.config?.EventingUrl;
+
+        if (!eventingUrl) {
+          const errorMessage = 'EventingUrl not available in config. Please ensure config is loaded first.';
+          logger.error({
+            message: errorMessage,
+          });
+          set({ error: new Error(errorMessage) });
+          return;
+        }
+
+        // Connect to the eventing hub
+        await signalRService.connectToHubWithEventingUrl({
+          name: Env.CHANNEL_HUB_NAME,
+          eventingUrl: eventingUrl,
+          hubName: Env.CHANNEL_HUB_NAME,
+          methods: [
+            'personnelStatusUpdated',
+            'personnelStaffingUpdated',
+            'unitStatusUpdated',
+            'callsUpdated',
+            'callAdded',
+            'callClosed',
+            'weatherAlertReceived',
+            'weatherAlertUpdated',
+            'weatherAlertExpired',
+            'onConnected',
+          ],
+        });
+
+        await signalRService.invoke(Env.CHANNEL_HUB_NAME, 'connect', parseInt(securityStore.getState().rights?.DepartmentId ?? '0'));
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error('Unknown error occurred');
         logger.error({
-          message: errorMessage,
+          message: 'Failed to connect to SignalR hubs',
+          context: { error: err },
         });
-        set({ error: new Error(errorMessage) });
-        return;
+        set({ error: err });
       }
-
-      // Connect to the eventing hub
-      await signalRService.connectToHubWithEventingUrl({
-        name: Env.CHANNEL_HUB_NAME,
-        eventingUrl: eventingUrl,
-        hubName: Env.CHANNEL_HUB_NAME,
-        methods: [
-          'personnelStatusUpdated',
-          'personnelStaffingUpdated',
-          'unitStatusUpdated',
-          'callsUpdated',
-          'callAdded',
-          'callClosed',
-          'weatherAlertReceived',
-          'weatherAlertUpdated',
-          'weatherAlertExpired',
-          'onConnected',
-        ],
-      });
-
-      await signalRService.invoke(Env.CHANNEL_HUB_NAME, 'connect', parseInt(securityStore.getState().rights?.DepartmentId ?? '0'));
-
-      signalRService.on('personnelStatusUpdated', (message) => {
-        logger.info({
-          message: 'personnelStatusUpdated',
-          context: { message },
-        });
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('personnelStaffingUpdated', (message) => {
-        logger.info({
-          message: 'personnelStaffingUpdated',
-          context: { message },
-        });
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('unitStatusUpdated', (message) => {
-        logger.info({
-          message: 'unitStatusUpdated',
-          context: { message },
-        });
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('callsUpdated', (message) => {
-        const now = Date.now();
-
-        logger.info({
-          message: 'callsUpdated',
-          context: { message, now },
-        });
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: now });
-      });
-
-      signalRService.on('callAdded', (message) => {
-        logger.info({
-          message: 'callAdded',
-          context: { message },
-        });
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('callClosed', (message) => {
-        logger.info({
-          message: 'callClosed',
-          context: { message },
-        });
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('weatherAlertReceived', (message) => {
-        logger.info({
-          message: 'weatherAlertReceived',
-          context: { message },
-        });
-        const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
-        if (alertId) {
-          useWeatherAlertsStore.getState().handleAlertReceived(alertId);
-        }
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('weatherAlertUpdated', (message) => {
-        logger.info({
-          message: 'weatherAlertUpdated',
-          context: { message },
-        });
-        const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
-        if (alertId) {
-          useWeatherAlertsStore.getState().handleAlertUpdated(alertId);
-        }
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('weatherAlertExpired', (message) => {
-        logger.info({
-          message: 'weatherAlertExpired',
-          context: { message },
-        });
-        const alertId = typeof message === 'string' ? message : ((message as Record<string, string>)?.AlertId ?? '');
-        if (alertId) {
-          useWeatherAlertsStore.getState().handleAlertExpired(alertId);
-        }
-        set({ lastUpdateMessage: JSON.stringify(message), lastUpdateTimestamp: Date.now() });
-      });
-
-      signalRService.on('onConnected', () => {
-        logger.info({
-          message: 'Connected to update SignalR hub',
-        });
-        set({ isUpdateHubConnected: true, error: null });
-      });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error('Unknown error occurred');
-      logger.error({
-        message: 'Failed to connect to SignalR hubs',
-        context: { error: err },
-      });
-      set({ error: err });
-    }
-  },
-  disconnectUpdateHub: async () => {
-    try {
-      await signalRService.disconnectFromHub(Env.CHANNEL_HUB_NAME);
-      set({ isUpdateHubConnected: false, lastUpdateMessage: null });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error('Unknown error occurred');
-      logger.error({
-        message: 'Failed to disconnect from SignalR hubs',
-        context: { error: err },
-      });
-      set({ error: err });
-    }
-  },
-  connectGeolocationHub: async () => {
-    try {
-      if (get().isGeolocationHubConnected) {
-        return;
-      }
-
-      set({ isGeolocationHubConnected: false, error: null });
-
-      // Get the eventing URL from the core store config
-      const coreState = useCoreStore.getState();
-      const eventingUrl = coreState.config?.EventingUrl;
-
-      if (!eventingUrl) {
-        const errorMessage = 'EventingUrl not available in config. Please ensure config is loaded first.';
+    },
+    disconnectUpdateHub: async () => {
+      try {
+        await signalRService.disconnectFromHub(Env.CHANNEL_HUB_NAME);
+        set({ isUpdateHubConnected: false, lastUpdateMessage: null });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error('Unknown error occurred');
         logger.error({
-          message: errorMessage,
+          message: 'Failed to disconnect from SignalR hubs',
+          context: { error: err },
         });
-        set({ error: new Error(errorMessage) });
-        return;
+        set({ error: err });
       }
+    },
+    connectGeolocationHub: async () => {
+      try {
+        if (get().isGeolocationHubConnected) {
+          return;
+        }
 
-      // Connect to the geolocation hub
-      await signalRService.connectToHubWithEventingUrl({
-        name: Env.REALTIME_GEO_HUB_NAME,
-        eventingUrl: eventingUrl,
-        hubName: Env.REALTIME_GEO_HUB_NAME,
-        methods: ['onPersonnelLocationUpdated', 'onUnitLocationUpdated', 'onGeolocationConnect'],
-      });
+        set({ isGeolocationHubConnected: false, error: null });
 
-      // Set up message handler
-      signalRService.on('onPersonnelLocationUpdated', (message) => {
-        set({ lastGeolocationMessage: JSON.stringify(message), lastGeolocationTimestamp: Date.now() });
-      });
+        // Get the eventing URL from the core store config
+        const coreState = useCoreStore.getState();
+        const eventingUrl = coreState.config?.EventingUrl;
 
-      signalRService.on('onUnitLocationUpdated', (message) => {
-        set({ lastGeolocationMessage: JSON.stringify(message), lastGeolocationTimestamp: Date.now() });
-      });
+        if (!eventingUrl) {
+          const errorMessage = 'EventingUrl not available in config. Please ensure config is loaded first.';
+          logger.error({
+            message: errorMessage,
+          });
+          set({ error: new Error(errorMessage) });
+          return;
+        }
 
-      signalRService.on('onGeolocationConnect', () => {
-        logger.info({
-          message: 'Connected to geolocation SignalR hub',
+        // Connect to the geolocation hub
+        await signalRService.connectToHubWithEventingUrl({
+          name: Env.REALTIME_GEO_HUB_NAME,
+          eventingUrl: eventingUrl,
+          hubName: Env.REALTIME_GEO_HUB_NAME,
+          methods: ['onPersonnelLocationUpdated', 'onUnitLocationUpdated', 'onGeolocationConnect'],
         });
-        set({ isGeolocationHubConnected: true, error: null });
-      });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error('Unknown error occurred');
-      logger.error({
-        message: 'Failed to connect to SignalR hubs',
-        context: { error: err },
-      });
-      set({ error: err });
-    }
-  },
-  disconnectGeolocationHub: async () => {
-    try {
-      await signalRService.disconnectFromHub(Env.REALTIME_GEO_HUB_NAME);
-      set({ isGeolocationHubConnected: false, lastGeolocationMessage: null });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error('Unknown error occurred');
-      logger.error({
-        message: 'Failed to disconnect from SignalR hubs',
-        context: { error: err },
-      });
-      set({ error: err });
-    }
-  },
-}));
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error('Unknown error occurred');
+        logger.error({
+          message: 'Failed to connect to SignalR hubs',
+          context: { error: err },
+        });
+        set({ error: err });
+      }
+    },
+    disconnectGeolocationHub: async () => {
+      try {
+        await signalRService.disconnectFromHub(Env.REALTIME_GEO_HUB_NAME);
+        set({ isGeolocationHubConnected: false, lastGeolocationMessage: null });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error('Unknown error occurred');
+        logger.error({
+          message: 'Failed to disconnect from SignalR hubs',
+          context: { error: err },
+        });
+        set({ error: err });
+      }
+    },
+  };
+});

--- a/src/translations/ar.json
+++ b/src/translations/ar.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "تأكيد التسجيل",
     "duration": "المدة",
     "elapsed": "المنقضي",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "سجل تسجيل الحضور",
     "last_check_in": "آخر تسجيل",
     "minutes_ago": "قبل {{count}} دقيقة",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Check-In bestätigen",
     "duration": "Dauer",
     "elapsed": "Vergangen",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Check-In Verlauf",
     "last_check_in": "Letzter Check-In",
     "minutes_ago": "vor {{count}} Min",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Confirm Check-In",
     "duration": "Duration",
     "elapsed": "Elapsed",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Check-In History",
     "last_check_in": "Last check-in",
     "minutes_ago": "{{count}} min ago",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Confirmar Registro",
     "duration": "Duración",
     "elapsed": "Transcurrido",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Historial de Registros",
     "last_check_in": "Último registro",
     "minutes_ago": "hace {{count}} min",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Confirmer le Pointage",
     "duration": "Durée",
     "elapsed": "Écoulé",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Historique des Pointages",
     "last_check_in": "Dernier pointage",
     "minutes_ago": "il y a {{count}} min",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Conferma Check-In",
     "duration": "Durata",
     "elapsed": "Trascorso",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Cronologia Check-In",
     "last_check_in": "Ultimo check-in",
     "minutes_ago": "{{count}} min fa",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Potwierdź Meldowanie",
     "duration": "Czas trwania",
     "elapsed": "Upłynęło",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Historia Meldowań",
     "last_check_in": "Ostatnie meldowanie",
     "minutes_ago": "{{count}} min temu",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Bekräfta incheckning",
     "duration": "Varaktighet",
     "elapsed": "Förfluten",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Incheckningshistorik",
     "last_check_in": "Senaste incheckning",
     "minutes_ago": "{{count}} min sedan",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -353,6 +353,7 @@
     "confirm_check_in": "Підтвердити Реєстрацію",
     "duration": "Тривалість",
     "elapsed": "Минуло",
+    "gps_coordinates": "GPS: {{latitude}}, {{longitude}}",
     "history": "Історія Реєстрацій",
     "last_check_in": "Остання реєстрація",
     "minutes_ago": "{{count}} хв тому",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR implements a comprehensive security hardening and bug fix pass across the Resgrid Responder mobile application.

## Security Improvements

- **SSO/Authentication hardening**: Added URL validation to reject non-HTTPS or malformed IdP authority URLs for both OIDC and SAML login flows. SAML login now includes CSRF protection via a state parameter with secure storage (SecureStore), 10-minute TTL, and state mismatch detection.
- **Android data protection**: Blocked unnecessary media permissions (`READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO`) and disabled ADB/cloud backup to prevent exposure of PII and auth tokens.
- **Location privacy**: The location store now only persists durable preferences (map lock, background enabled) — live coordinates, heading, and timestamps are no longer persisted to storage.
- **Log sanitization**: Push notification tokens are truncated in logs, notification payloads are limited to event codes, and error logging uses structured error context instead of raw objects.
- **Logout cleanup**: Logout now fully clears app data, persisted stores, and pending SAML state from secure storage.

## Bug Fixes

- **Token refresh deduplication**: Concurrent `refreshAccessToken` calls now share a single in-flight promise, preventing duplicate refresh requests.
- **SignalR reconnection**: Intentional disconnects no longer trigger reconnection attempts, and pending reconnection timers are properly cancelled on disconnect. SignalR logging reduced from Information to Warning level.
- **SignalR message handling**: Messages are now stored as objects instead of being JSON-stringified, fixing parsing issues in status update consumers.
- **Location service**: Made `startLocationUpdates` idempotent by removing existing subscriptions before creating new ones.
- **Offline queue**: Added stale failed event purging (7-day TTL), max retry limit (5 attempts), queue size cap (500 events), network listener lifecycle management, and corrupt data recovery.
- **Cache manager**: Corrupt cache entries are now detected and removed instead of crashing.
- **Check-in store**: Added debouncing for global overdue count fetches to prevent rapid-fire API calls.

## Performance Optimizations

- Refactored Zustand store usage across all major screens (calendar, calls, messages, personnel, units, shifts, protocols, contacts) to use atomic selectors instead of whole-store destructuring, reducing unnecessary re-renders.
- Wrapped list item renderers in `useCallback`, added `React.memo` to card components (`CallCard`, `PersonnelCard`, `UnitCard`, `PinMarker`, `MapPins`), and memoized computed values.
- Parallelized independent initialization tasks (analytics, CallKeep, weather alerts, audio services, offline queue) using `Promise.allSettled`.

## Test Coverage

- Added tests for SSO URL validation, SAML state management, token refresh deduplication, SignalR intentional disconnect behavior, offline queue purging/size limits, cache corruption handling, location persistence scoping, and idempotent location subscription restarts.
- Updated all store mock patterns to use selector-based implementations matching the refactored store usage.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPS coordinate details to check-ins with localized translations.
  * Improved SSO login validation and added safer SAML sign-in state handling.
  * Added offline queue retry scheduling, cleanup, and network-listener management.
  * Improved location, map, and SignalR connection reliability.

* **Bug Fixes**
  * Prevented duplicate location watchers and unnecessary SignalR reconnections.
  * Added protection against corrupted cached data and stale location information.
  * Improved app startup resilience when individual services fail.
  * Restricted access to media permissions and disabled Android backups for added privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->