### PR TITLE
RR-T46 Web fixes and Voice freeze on iOS

### DIFF
--- a/.github/workflows/react-native-cicd.yml
+++ b/.github/workflows/react-native-cicd.yml
@@ -356,6 +356,8 @@ jobs:
             fi
             # Remove "Summary by CodeRabbit" line
             NOTES="$(printf '%s\n' "$NOTES" | grep -v "Summary by CodeRabbit")"
+            # Replace occurrences of "PR" with "Release"
+            NOTES="$(printf '%s\n' "$NOTES" | sed 's/\bPR\b/Release/g')"
           else
             NOTES="$(git log -n 5 --pretty=format:'- %s')"
           fi

--- a/metro.config.js
+++ b/metro.config.js
@@ -9,6 +9,48 @@ const config = getSentryExpoConfig(__dirname, {
   isCSSEnabled: true,
 });
 
+// Force zustand (and subpaths) to resolve to its CJS build on web.
+// Its ESM build uses `import.meta.env`, which Metro's web output does not support.
+const path = require('path');
+const zustandCjsRoot = path.dirname(require.resolve('zustand/package.json'));
+const zustandSubpathMap = {
+  zustand: 'index.js',
+  'zustand/vanilla': 'vanilla.js',
+  'zustand/traditional': 'traditional.js',
+  'zustand/middleware': 'middleware.js',
+  'zustand/shallow': 'shallow.js',
+  'zustand/context': 'context.js',
+  'zustand/middleware/immer': 'middleware/immer.js',
+};
+const defaultResolveRequest = config.resolver.resolveRequest;
+const webModuleStubs = {
+  'react-native-ble-manager': path.resolve(__dirname, 'src/stubs/react-native-ble-manager.web.ts'),
+  '@livekit/react-native': path.resolve(__dirname, 'src/stubs/livekit-react-native.web.ts'),
+  '@livekit/react-native-webrtc': path.resolve(__dirname, 'src/stubs/livekit-react-native-webrtc.web.ts'),
+  'countly-sdk-react-native-bridge': path.resolve(__dirname, 'src/stubs/countly-sdk.web.ts'),
+  'countly-sdk-react-native-bridge/CountlyConfig': path.resolve(__dirname, 'src/stubs/countly-config.web.ts'),
+};
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (platform === 'web') {
+    if (Object.prototype.hasOwnProperty.call(zustandSubpathMap, moduleName)) {
+      return {
+        type: 'sourceFile',
+        filePath: path.join(zustandCjsRoot, zustandSubpathMap[moduleName]),
+      };
+    }
+    if (Object.prototype.hasOwnProperty.call(webModuleStubs, moduleName)) {
+      return {
+        type: 'sourceFile',
+        filePath: webModuleStubs[moduleName],
+      };
+    }
+  }
+  if (defaultResolveRequest) {
+    return defaultResolveRequest(context, moduleName, platform);
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 // 1. Watch all files within the monorepo
 // 2. Let Metro know where to resolve packages and in what order
 //config.resolver.nodeModulesPaths = [path.resolve(__dirname, 'node_modules')];

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "lodash": "^4.17.21",
     "lodash.memoize": "~4.1.2",
     "lucide-react-native": "~0.475.0",
+    "mapbox-gl": "^2.15.0",
     "moti": "~0.29.0",
     "nativewind": "~4.1.21",
     "react": "19.1.0",

--- a/src/components/audio-stream/audio-stream-bottom-sheet.tsx
+++ b/src/components/audio-stream/audio-stream-bottom-sheet.tsx
@@ -1,13 +1,14 @@
 import { useFocusEffect } from '@react-navigation/native';
-import { Loader, Volume2, VolumeX } from 'lucide-react-native';
+import { CheckCircle, Loader, Volume2, VolumeX } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
 import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ScrollView } from 'react-native';
 
 import { Actionsheet, ActionsheetBackdrop, ActionsheetContent, ActionsheetDragIndicator, ActionsheetDragIndicatorWrapper } from '@/components/ui/actionsheet';
 import { Button, ButtonText } from '@/components/ui/button';
 import { HStack } from '@/components/ui/hstack';
-import { Select, SelectBackdrop, SelectContent, SelectDragIndicator, SelectDragIndicatorWrapper, SelectIcon, SelectInput, SelectItem, SelectPortal, SelectTrigger } from '@/components/ui/select';
+import { Pressable } from '@/components/ui/pressable';
 import { Text } from '@/components/ui/text';
 import { VStack } from '@/components/ui/vstack';
 import { useAnalytics } from '@/hooks/use-analytics';
@@ -96,6 +97,22 @@ export const AudioStreamBottomSheet = () => {
     return currentStream ? currentStream.Id : 'none';
   };
 
+  const renderStreamOption = (streamId: string, label: string) => {
+    const isSelected = getCurrentStreamValue() === streamId;
+    return (
+      <Pressable
+        key={streamId}
+        onPress={() => handleStreamSelection(streamId)}
+        disabled={isLoading || isBuffering}
+        testID={`stream-option-${streamId}`}
+        className={`flex-row items-center justify-between rounded-lg border p-3 ${isSelected ? 'border-blue-600 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30' : 'border-gray-200 dark:border-gray-700'} ${isLoading || isBuffering ? 'opacity-50' : ''}`}
+      >
+        <Text className={`flex-1 ${isSelected ? 'font-medium text-blue-900 dark:text-blue-100' : 'text-gray-900 dark:text-gray-100'}`}>{label}</Text>
+        {isSelected ? <CheckCircle size={20} color="#2563eb" /> : null}
+      </Pressable>
+    );
+  };
+
   const getDisplayText = () => {
     if (isLoading) {
       return t('audio_streams.loading_stream');
@@ -141,28 +158,12 @@ export const AudioStreamBottomSheet = () => {
                 <Text className="text-sm text-gray-500">{t('audio_streams.loading_streams')}</Text>
               </HStack>
             ) : (
-              <Select selectedValue={getCurrentStreamValue()} onValueChange={handleStreamSelection} isDisabled={isLoading || isBuffering}>
-                <SelectTrigger>
-                  <SelectInput placeholder={t('audio_streams.select_placeholder')} value={currentStream ? currentStream.Name : t('audio_streams.none')} />
-                  <SelectIcon />
-                </SelectTrigger>
-                <SelectPortal>
-                  <SelectBackdrop />
-                  <SelectContent className="max-h-[60vh] pb-20">
-                    <SelectDragIndicatorWrapper>
-                      <SelectDragIndicator />
-                    </SelectDragIndicatorWrapper>
-
-                    {/* None option */}
-                    <SelectItem label={t('audio_streams.none')} value="none" />
-
-                    {/* Available streams */}
-                    {availableStreams.map((stream) => (
-                      <SelectItem key={stream.Id} label={stream.Name} value={stream.Id} />
-                    ))}
-                  </SelectContent>
-                </SelectPortal>
-              </Select>
+              <ScrollView className="max-h-[40vh]">
+                <VStack space="sm">
+                  {renderStreamOption('none', t('audio_streams.none'))}
+                  {availableStreams.map((stream) => renderStreamOption(stream.Id, stream.Name))}
+                </VStack>
+              </ScrollView>
             )}
           </VStack>
 

--- a/src/components/audio-stream/audio-stream-bottom-sheet.tsx
+++ b/src/components/audio-stream/audio-stream-bottom-sheet.tsx
@@ -15,6 +15,34 @@ import { useAnalytics } from '@/hooks/use-analytics';
 import { useToast } from '@/hooks/use-toast';
 import { useAudioStreamStore } from '@/stores/app/audio-stream-store';
 
+interface StreamOptionProps {
+  streamId: string;
+  label: string;
+  isSelected: boolean;
+  isDisabled: boolean;
+  onSelect: (streamId: string) => void;
+}
+
+const StreamOption: React.FC<StreamOptionProps> = React.memo(({ streamId, label, isSelected, isDisabled, onSelect }) => {
+  const handlePress = React.useCallback(() => {
+    onSelect(streamId);
+  }, [onSelect, streamId]);
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      disabled={isDisabled}
+      testID={`stream-option-${streamId}`}
+      className={`flex-row items-center justify-between rounded-lg border p-3 ${isSelected ? 'border-blue-600 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30' : 'border-gray-200 dark:border-gray-700'} ${isDisabled ? 'opacity-50' : ''}`}
+    >
+      <Text className={`flex-1 ${isSelected ? 'font-medium text-blue-900 dark:text-blue-100' : 'text-gray-900 dark:text-gray-100'}`}>{label}</Text>
+      {isSelected ? <CheckCircle size={20} color="#2563eb" /> : null}
+    </Pressable>
+  );
+});
+
+StreamOption.displayName = 'StreamOption';
+
 export const AudioStreamBottomSheet = () => {
   const { t } = useTranslation();
   const { colorScheme } = useColorScheme();
@@ -98,19 +126,7 @@ export const AudioStreamBottomSheet = () => {
   };
 
   const renderStreamOption = (streamId: string, label: string) => {
-    const isSelected = getCurrentStreamValue() === streamId;
-    return (
-      <Pressable
-        key={streamId}
-        onPress={() => handleStreamSelection(streamId)}
-        disabled={isLoading || isBuffering}
-        testID={`stream-option-${streamId}`}
-        className={`flex-row items-center justify-between rounded-lg border p-3 ${isSelected ? 'border-blue-600 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30' : 'border-gray-200 dark:border-gray-700'} ${isLoading || isBuffering ? 'opacity-50' : ''}`}
-      >
-        <Text className={`flex-1 ${isSelected ? 'font-medium text-blue-900 dark:text-blue-100' : 'text-gray-900 dark:text-gray-100'}`}>{label}</Text>
-        {isSelected ? <CheckCircle size={20} color="#2563eb" /> : null}
-      </Pressable>
-    );
+    return <StreamOption key={streamId} streamId={streamId} label={label} isSelected={getCurrentStreamValue() === streamId} isDisabled={isLoading || isBuffering} onSelect={handleStreamSelection} />;
   };
 
   const getDisplayText = () => {

--- a/src/components/maps/static-map.web.tsx
+++ b/src/components/maps/static-map.web.tsx
@@ -1,5 +1,5 @@
 import Mapbox from '@rnmapbox/maps';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet } from 'react-native';
 
@@ -16,8 +16,32 @@ interface StaticMapProps {
   onPress?: () => void;
 }
 
-const StaticMap: React.FC<StaticMapProps> = ({ latitude, longitude, address, zoom = 15, height = 200, showUserLocation: _showUserLocation = false, onPress }) => {
+const StaticMap: React.FC<StaticMapProps> = ({ latitude, longitude, address, zoom = 15, height = 200, showUserLocation = false, onPress }) => {
   const { t } = useTranslation();
+  const [userCoordinate, setUserCoordinate] = useState<[number, number] | null>(null);
+
+  useEffect(() => {
+    if (!showUserLocation || typeof navigator === 'undefined' || !navigator.geolocation) {
+      return;
+    }
+
+    let cancelled = false;
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        if (!cancelled) {
+          setUserCoordinate([position.coords.longitude, position.coords.latitude]);
+        }
+      },
+      () => {
+        // Geolocation unavailable or denied — skip rendering the indicator
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showUserLocation]);
   if (!latitude || !longitude) {
     return (
       <Box className="w-full items-center justify-center bg-gray-200" style={{ height }}>
@@ -41,6 +65,21 @@ const StaticMap: React.FC<StaticMapProps> = ({ latitude, longitude, address, zoo
             }}
           />
         </Mapbox.MarkerView>
+
+        {showUserLocation && userCoordinate ? (
+          <Mapbox.MarkerView coordinate={userCoordinate}>
+            <div
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: 8,
+                backgroundColor: '#3b82f6',
+                border: '3px solid #ffffff',
+                boxShadow: '0 0 0 4px rgba(59, 130, 246, 0.25)',
+              }}
+            />
+          </Mapbox.MarkerView>
+        ) : null}
       </Mapbox.MapView>
 
       {onPress ? <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={address || t('call_detail.title')} testID="static-map-press-overlay" style={StyleSheet.absoluteFill} /> : null}
@@ -56,6 +95,7 @@ const StaticMap: React.FC<StaticMapProps> = ({ latitude, longitude, address, zoo
             padding: 8,
             color: 'white',
             fontSize: 12,
+            pointerEvents: 'none',
           }}
         >
           {address}

--- a/src/components/maps/static-map.web.tsx
+++ b/src/components/maps/static-map.web.tsx
@@ -1,0 +1,68 @@
+import Mapbox from '@rnmapbox/maps';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable, StyleSheet } from 'react-native';
+
+import { Box } from '@/components/ui/box';
+import { Text } from '@/components/ui/text';
+
+interface StaticMapProps {
+  latitude: number;
+  longitude: number;
+  address?: string;
+  zoom?: number;
+  height?: number;
+  showUserLocation?: boolean;
+  onPress?: () => void;
+}
+
+const StaticMap: React.FC<StaticMapProps> = ({ latitude, longitude, address, zoom = 15, height = 200, showUserLocation: _showUserLocation = false, onPress }) => {
+  const { t } = useTranslation();
+  if (!latitude || !longitude) {
+    return (
+      <Box className="w-full items-center justify-center bg-gray-200" style={{ height }}>
+        <Text className="text-gray-500">{t('call_detail.no_location')}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <div style={{ width: '100%', height, position: 'relative', overflow: 'hidden' }}>
+      <Mapbox.MapView style={{ flex: 1, width: '100%', height }} zoomEnabled={false} scrollEnabled={false} rotateEnabled={false} pitchEnabled={false}>
+        <Mapbox.Camera zoomLevel={zoom} centerCoordinate={[longitude, latitude]} animationDuration={0} />
+        <Mapbox.MarkerView coordinate={[longitude, latitude]}>
+          <div
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 10,
+              backgroundColor: '#ef4444',
+              border: '3px solid #ffffff',
+            }}
+          />
+        </Mapbox.MarkerView>
+      </Mapbox.MapView>
+
+      {onPress ? <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={address || t('call_detail.title')} testID="static-map-press-overlay" style={StyleSheet.absoluteFill} /> : null}
+
+      {address ? (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.6)',
+            padding: 8,
+            color: 'white',
+            fontSize: 12,
+          }}
+        >
+          {address}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default StaticMap;

--- a/src/components/ui/box/index.web.tsx
+++ b/src/components/ui/box/index.web.tsx
@@ -5,7 +5,7 @@ import { boxStyle } from './styles';
 
 type IBoxProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof boxStyle> & { className?: string };
 
-const Box = React.forwardRef<HTMLDivElement, IBoxProps>(({ className, ...props }, ref) => {
+const Box = React.forwardRef<HTMLDivElement, IBoxProps>(({ className, style: _style, ...props }, ref) => {
   return <div ref={ref} className={boxStyle({ class: className })} {...props} />;
 });
 

--- a/src/components/ui/card/index.web.tsx
+++ b/src/components/ui/card/index.web.tsx
@@ -5,7 +5,7 @@ import { cardStyle } from './styles';
 
 type ICardProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof cardStyle>;
 
-const Card = React.forwardRef<HTMLDivElement, ICardProps>(({ className, size = 'md', variant = 'elevated', ...props }, ref) => {
+const Card = React.forwardRef<HTMLDivElement, ICardProps>(({ className, size = 'md', variant = 'elevated', style: _style, ...props }, ref) => {
   return <div className={cardStyle({ size, variant, class: className })} {...props} ref={ref} />;
 });
 

--- a/src/components/ui/center/index.web.tsx
+++ b/src/components/ui/center/index.web.tsx
@@ -5,7 +5,7 @@ import { centerStyle } from './styles';
 
 type ICenterProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof centerStyle>;
 
-const Center = React.forwardRef<HTMLDivElement, ICenterProps>(({ className, ...props }, ref) => {
+const Center = React.forwardRef<HTMLDivElement, ICenterProps>(({ className, style: _style, ...props }, ref) => {
   return <div className={centerStyle({ class: className })} {...props} ref={ref} />;
 });
 

--- a/src/components/ui/grid/index.web.tsx
+++ b/src/components/ui/grid/index.web.tsx
@@ -19,7 +19,7 @@ type IGridProps = React.ComponentPropsWithoutRef<'div'> &
     };
   };
 
-const Grid = React.forwardRef<HTMLDivElement, IGridProps>(function Grid({ className, _extra, ...props }, ref) {
+const Grid = React.forwardRef<HTMLDivElement, IGridProps>(function Grid({ className, _extra, style: _style, ...props }, ref) {
   const gridClass = _extra?.className;
   const finalGridClass = gridClass ?? '';
   return (
@@ -40,7 +40,7 @@ type IGridItemProps = React.ComponentPropsWithoutRef<'div'> &
       className: string;
     };
   };
-const GridItem = React.forwardRef<HTMLDivElement, IGridItemProps>(function GridItem({ className, _extra, ...props }, ref) {
+const GridItem = React.forwardRef<HTMLDivElement, IGridItemProps>(function GridItem({ className, _extra, style: _style, ...props }, ref) {
   const gridItemClass = _extra?.className;
 
   const finalGridItemClass = gridItemClass ?? '';

--- a/src/components/ui/heading/index.web.tsx
+++ b/src/components/ui/heading/index.web.tsx
@@ -8,7 +8,7 @@ type IHeadingProps = VariantProps<typeof headingStyle> &
   };
 
 const MappedHeading = memo(
-  forwardRef<HTMLHeadingElement, IHeadingProps>(function MappedHeading({ size, className, isTruncated, bold, underline, strikeThrough, sub, italic, highlight, ...props }, ref) {
+  forwardRef<HTMLHeadingElement, IHeadingProps>(function MappedHeading({ size, className, isTruncated, bold, underline, strikeThrough, sub, italic, highlight, style: _style, ...props }, ref) {
     switch (size) {
       case '5xl':
       case '4xl':
@@ -144,7 +144,7 @@ const MappedHeading = memo(
 );
 
 const Heading = memo(
-  forwardRef<HTMLHeadingElement, IHeadingProps>(function Heading({ className, size = 'lg', as: AsComp, ...props }, ref) {
+  forwardRef<HTMLHeadingElement, IHeadingProps>(function Heading({ className, size = 'lg', as: AsComp, style: _style, ...props }, ref) {
     const { isTruncated, bold, underline, strikeThrough, sub, italic, highlight } = props;
 
     if (AsComp) {

--- a/src/components/ui/hstack/index.web.tsx
+++ b/src/components/ui/hstack/index.web.tsx
@@ -5,7 +5,7 @@ import { hstackStyle } from './styles';
 
 type IHStackProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof hstackStyle>;
 
-const HStack = React.forwardRef<React.ElementRef<'div'>, IHStackProps>(({ className, space, reversed, ...props }, ref) => {
+const HStack = React.forwardRef<React.ElementRef<'div'>, IHStackProps>(({ className, space, reversed, style: _style, ...props }, ref) => {
   return <div className={hstackStyle({ space, reversed, class: className })} {...props} ref={ref} />;
 });
 

--- a/src/components/ui/skeleton/index.web.tsx
+++ b/src/components/ui/skeleton/index.web.tsx
@@ -9,7 +9,7 @@ type ISkeletonProps = React.ComponentPropsWithoutRef<'div'> &
     isLoaded?: boolean;
   };
 
-const Skeleton = React.forwardRef<HTMLDivElement, ISkeletonProps>(({ className, variant = 'rounded', children, speed = 2, startColor = 'bg-background-200', isLoaded = false, ...props }, ref) => {
+const Skeleton = React.forwardRef<HTMLDivElement, ISkeletonProps>(({ className, variant = 'rounded', children, speed = 2, startColor = 'bg-background-200', isLoaded = false, style: _style, ...props }, ref) => {
   if (!isLoaded) {
     return (
       <div
@@ -34,7 +34,7 @@ type ISkeletonTextProps = React.ComponentPropsWithoutRef<'div'> &
     startColor?: string;
   };
 
-const SkeletonText = React.forwardRef<HTMLDivElement, ISkeletonTextProps>(({ className, _lines, isLoaded = false, startColor = 'bg-background-200', gap = 2, children, ...props }, ref) => {
+const SkeletonText = React.forwardRef<HTMLDivElement, ISkeletonTextProps>(({ className, _lines, isLoaded = false, startColor = 'bg-background-200', gap = 2, children, style: _style, ...props }, ref) => {
   if (!isLoaded) {
     if (_lines) {
       return (

--- a/src/components/ui/text/index.web.tsx
+++ b/src/components/ui/text/index.web.tsx
@@ -6,7 +6,7 @@ import { textStyle } from './styles';
 type ITextProps = React.ComponentProps<'span'> & VariantProps<typeof textStyle>;
 
 const Text = React.forwardRef<React.ElementRef<'span'>, ITextProps>(
-  ({ className, isTruncated, bold, underline, strikeThrough, size = 'md', sub, italic, highlight, ...props }: { className?: string } & ITextProps, ref) => {
+  ({ className, isTruncated, bold, underline, strikeThrough, size = 'md', sub, italic, highlight, style: _style, ...props }: { className?: string } & ITextProps, ref) => {
     return (
       <span
         className={textStyle({

--- a/src/components/ui/vstack/index.web.tsx
+++ b/src/components/ui/vstack/index.web.tsx
@@ -5,7 +5,7 @@ import { vstackStyle } from './styles';
 
 type IVStackProps = React.ComponentProps<'div'> & VariantProps<typeof vstackStyle>;
 
-const VStack = React.forwardRef<React.ComponentRef<'div'>, IVStackProps>(function VStack({ className, space, reversed, ...props }, ref) {
+const VStack = React.forwardRef<React.ComponentRef<'div'>, IVStackProps>(function VStack({ className, space, reversed, style: _style, ...props }, ref) {
   return <div className={vstackStyle({ space, reversed, class: className })} {...props} ref={ref} />;
 });
 

--- a/src/stores/app/__tests__/livekit-store.test.ts
+++ b/src/stores/app/__tests__/livekit-store.test.ts
@@ -43,7 +43,7 @@ jest.mock('../../../services/callkeep.service.ios', () => ({
 }));
 
 import { Platform } from 'react-native';
-import { getRecordingPermissionsAsync, requestRecordingPermissionsAsync } from 'expo-audio';
+import { check, request, RESULTS } from 'react-native-permissions';
 
 
 
@@ -107,10 +107,21 @@ jest.mock('../../../api/voice', () => ({
   connectToVoiceSession: jest.fn(),
 }));
 
-// Mock expo-audio
-jest.mock('expo-audio', () => ({
-  getRecordingPermissionsAsync: jest.fn(),
-  requestRecordingPermissionsAsync: jest.fn(),
+// Mock react-native-permissions
+jest.mock('react-native-permissions', () => ({
+  check: jest.fn(),
+  request: jest.fn(),
+  PERMISSIONS: {
+    ANDROID: { RECORD_AUDIO: 'android.permission.RECORD_AUDIO' },
+    IOS: { MICROPHONE: 'ios.permission.MICROPHONE' },
+  },
+  RESULTS: {
+    UNAVAILABLE: 'unavailable',
+    DENIED: 'denied',
+    LIMITED: 'limited',
+    GRANTED: 'granted',
+    BLOCKED: 'blocked',
+  },
 }));
 
 // Mock logger
@@ -129,8 +140,8 @@ jest.mock('react-native', () => ({
   },
 }));
 
-const mockGetRecordingPermissionsAsync = getRecordingPermissionsAsync as jest.MockedFunction<typeof getRecordingPermissionsAsync>;
-const mockRequestRecordingPermissionsAsync = requestRecordingPermissionsAsync as jest.MockedFunction<typeof requestRecordingPermissionsAsync>;
+const mockCheck = check as jest.MockedFunction<typeof check>;
+const mockRequest = request as jest.MockedFunction<typeof request>;
 const mockLogger = logger as jest.Mocked<typeof logger>;
 
 describe('LiveKit Store - Permission Management', () => {
@@ -154,27 +165,14 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should successfully request permissions when not granted initially', async () => {
-      // Mock initial permission check - not granted
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'undetermined',
-      } as any);
-
-      // Mock permission request - granted
-      mockRequestRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: true,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'granted',
-      } as any);
+      mockCheck.mockResolvedValueOnce(RESULTS.DENIED);
+      mockRequest.mockResolvedValueOnce(RESULTS.GRANTED);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
       expect(mockLogger.info).toHaveBeenCalledWith({
         message: 'Microphone permission granted successfully',
         context: { platform: 'android' },
@@ -182,19 +180,13 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should skip request when permissions already granted', async () => {
-      // Mock initial permission check - already granted
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: true,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'granted',
-      } as any);
+      mockCheck.mockResolvedValueOnce(RESULTS.GRANTED);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).not.toHaveBeenCalled();
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).not.toHaveBeenCalled();
       expect(mockLogger.info).toHaveBeenCalledWith({
         message: 'Microphone permission granted successfully',
         context: { platform: 'android' },
@@ -202,42 +194,28 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should handle permission denial', async () => {
-      // Mock initial permission check - not granted
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'undetermined',
-      } as any);
-
-      // Mock permission request - denied
-      mockRequestRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'denied',
-      } as any);
+      mockCheck.mockResolvedValueOnce(RESULTS.DENIED);
+      mockRequest.mockResolvedValueOnce(RESULTS.BLOCKED);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith({
         message: 'Microphone permission not granted',
-        context: { platform: 'android' },
+        context: { platform: 'android', result: RESULTS.BLOCKED },
       });
     });
 
     it('should handle permission errors gracefully', async () => {
-      // Mock initial permission check - throws error
-      mockGetRecordingPermissionsAsync.mockRejectedValueOnce(new Error('Permission API error'));
+      mockCheck.mockRejectedValueOnce(new Error('Permission API error'));
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).not.toHaveBeenCalled();
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).not.toHaveBeenCalled();
       expect(mockLogger.error).toHaveBeenCalledWith({
         message: 'Failed to request permissions',
         context: { platform: 'android', error: expect.any(Error) },
@@ -245,22 +223,14 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should handle request API errors', async () => {
-      // Mock initial permission check - not granted
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'undetermined',
-      } as any);
-
-      // Mock permission request - throws error
-      mockRequestRecordingPermissionsAsync.mockRejectedValueOnce(new Error('Request API error'));
+      mockCheck.mockResolvedValueOnce(RESULTS.DENIED);
+      mockRequest.mockRejectedValueOnce(new Error('Request API error'));
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith({
         message: 'Failed to request permissions',
         context: { platform: 'android', error: expect.any(Error) },
@@ -274,27 +244,14 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should successfully request permissions on iOS', async () => {
-      // Mock initial permission check - not granted
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'undetermined',
-      } as any);
-
-      // Mock permission request - granted
-      mockRequestRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: true,
-        canAskAgain: true,
-        expires: 'never',
-        status: 'granted',
-      } as any);
+      mockCheck.mockResolvedValueOnce(RESULTS.DENIED);
+      mockRequest.mockResolvedValueOnce(RESULTS.GRANTED);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
       expect(mockLogger.info).toHaveBeenCalledWith({
         message: 'Microphone permission granted successfully',
         context: { platform: 'ios' },
@@ -302,30 +259,17 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should handle iOS permission denial', async () => {
-      // Mock initial permission check - not granted
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: false,
-        expires: 'never',
-        status: 'denied',
-      } as any);
-
-      // Mock permission request - still denied
-      mockRequestRecordingPermissionsAsync.mockResolvedValueOnce({
-        granted: false,
-        canAskAgain: false,
-        expires: 'never',
-        status: 'denied',
-      } as any);
+      mockCheck.mockResolvedValueOnce(RESULTS.BLOCKED);
+      mockRequest.mockResolvedValueOnce(RESULTS.BLOCKED);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith({
         message: 'Microphone permission not granted',
-        context: { platform: 'ios' },
+        context: { platform: 'ios', result: RESULTS.BLOCKED },
       });
     });
   });
@@ -339,8 +283,8 @@ describe('LiveKit Store - Permission Management', () => {
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).not.toHaveBeenCalled();
-      expect(mockRequestRecordingPermissionsAsync).not.toHaveBeenCalled();
+      expect(mockCheck).not.toHaveBeenCalled();
+      expect(mockRequest).not.toHaveBeenCalled();
       // For unsupported platforms, the function just returns without logging
       expect(mockLogger.info).not.toHaveBeenCalled();
       expect(mockLogger.error).not.toHaveBeenCalled();
@@ -353,32 +297,33 @@ describe('LiveKit Store - Permission Management', () => {
     });
 
     it('should handle undefined permission response', async () => {
-      // Mock initial permission check - returns undefined
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce(undefined as any);
+      mockCheck.mockResolvedValueOnce(undefined as any);
+      mockRequest.mockResolvedValueOnce(RESULTS.DENIED);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith({
-        message: 'Failed to request permissions',
-        context: { platform: 'android', error: expect.any(Error) },
+        message: 'Microphone permission not granted',
+        context: { platform: 'android', result: RESULTS.DENIED },
       });
     });
 
-    it('should handle malformed permission response', async () => {
-      // Mock initial permission check - missing granted property
-      mockGetRecordingPermissionsAsync.mockResolvedValueOnce({
-        canAskAgain: true,
-        expires: 'never',
-        status: 'undetermined',
-      } as any);
+    it('should handle unavailable permission', async () => {
+      mockCheck.mockResolvedValueOnce(RESULTS.UNAVAILABLE);
+      mockRequest.mockResolvedValueOnce(RESULTS.UNAVAILABLE);
 
       const { requestPermissions } = useLiveKitStore.getState();
       await requestPermissions();
 
-      expect(mockGetRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
-      expect(mockRequestRecordingPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith({
+        message: 'Microphone permission not granted',
+        context: { platform: 'android', result: RESULTS.UNAVAILABLE },
+      });
     });
   });
 

--- a/src/stores/app/livekit-store.ts
+++ b/src/stores/app/livekit-store.ts
@@ -1,9 +1,9 @@
 import { AudioSession } from '@livekit/react-native';
 import notifee, { AndroidImportance } from '@notifee/react-native';
-import { getRecordingPermissionsAsync, requestRecordingPermissionsAsync } from 'expo-audio';
 import { Audio } from 'expo-av';
 import { ConnectionState, Room, RoomEvent } from 'livekit-client';
 import { Platform } from 'react-native';
+import { check, PERMISSIONS, request, RESULTS } from 'react-native-permissions';
 import { create } from 'zustand';
 
 import { getCanConnectToVoiceSession, getDepartmentVoiceSettings } from '../../api/voice';
@@ -168,15 +168,18 @@ export const useLiveKitStore = create<LiveKitState>((set, get) => ({
   requestPermissions: async () => {
     try {
       if (Platform.OS === 'android' || Platform.OS === 'ios') {
-        // Use expo-audio for both Android and iOS microphone permissions
-        const micPermission = await getRecordingPermissionsAsync();
+        // Use react-native-permissions for both Android and iOS microphone permissions.
+        // NOTE: expo-audio's permission request activates AVAudioSession on iOS which
+        // deadlocks against expo-av's active session and freezes the app.
+        const permission = Platform.OS === 'ios' ? PERMISSIONS.IOS.MICROPHONE : PERMISSIONS.ANDROID.RECORD_AUDIO;
 
-        if (!micPermission.granted) {
-          const result = await requestRecordingPermissionsAsync();
-          if (!result.granted) {
+        const status = await check(permission);
+        if (status !== RESULTS.GRANTED) {
+          const result = await request(permission);
+          if (result !== RESULTS.GRANTED) {
             logger.error({
               message: 'Microphone permission not granted',
-              context: { platform: Platform.OS },
+              context: { platform: Platform.OS, result },
             });
             return;
           }
@@ -212,10 +215,10 @@ export const useLiveKitStore = create<LiveKitState>((set, get) => ({
       // BEFORE starting a foreground service with microphone type.
       // This is a security requirement - the app must be "eligible" to use the microphone.
       if (Platform.OS === 'android') {
-        const micPermission = await getRecordingPermissionsAsync();
-        if (!micPermission.granted) {
-          const result = await requestRecordingPermissionsAsync();
-          if (!result.granted) {
+        const status = await check(PERMISSIONS.ANDROID.RECORD_AUDIO);
+        if (status !== RESULTS.GRANTED) {
+          const result = await request(PERMISSIONS.ANDROID.RECORD_AUDIO);
+          if (result !== RESULTS.GRANTED) {
             logger.error({
               message: 'Cannot connect to room - microphone permission denied',
               context: { platform: Platform.OS },

--- a/src/stubs/countly-config.web.ts
+++ b/src/stubs/countly-config.web.ts
@@ -1,0 +1,18 @@
+export default class CountlyConfig {
+  constructor(_serverUrl?: string, _appKey?: string) {}
+  setLoggingEnabled() {
+    return this;
+  }
+  enableCrashReporting() {
+    return this;
+  }
+  setRequiresConsent() {
+    return this;
+  }
+  giveAllConsent() {
+    return this;
+  }
+  setLocation() {
+    return this;
+  }
+}

--- a/src/stubs/countly-sdk.web.ts
+++ b/src/stubs/countly-sdk.web.ts
@@ -1,0 +1,16 @@
+const Countly = {
+  initWithConfig: async (_config?: unknown) => {},
+  start: async () => {},
+  halt: async () => {},
+  endSession: async () => {},
+  setUserData: async (_userData?: unknown) => {},
+  events: {
+    recordEvent: async (_eventName?: string, _segmentation?: unknown, _count?: number, _sum?: number) => {},
+  },
+  consent: {
+    giveConsent: async () => {},
+    removeConsent: async () => {},
+  },
+};
+
+export default Countly;

--- a/src/stubs/livekit-react-native-webrtc.web.ts
+++ b/src/stubs/livekit-react-native-webrtc.web.ts
@@ -1,0 +1,34 @@
+export const RTCAudioSession = {
+  audioSessionDidActivate: () => {},
+  audioSessionDidDeactivate: () => {},
+  addListener: () => ({ remove: () => {} }),
+  removeListeners: () => {},
+};
+
+export const RTCView = () => null;
+
+export class MediaStream {
+  id = '';
+  active = false;
+}
+
+export class MediaStreamTrack {
+  id = '';
+  kind = '';
+  enabled = true;
+  stop() {}
+}
+
+export const mediaDevices = {
+  getUserMedia: async () => {
+    throw new Error('getUserMedia via @livekit/react-native-webrtc is not supported on web');
+  },
+  getDisplayMedia: async () => {
+    throw new Error('getDisplayMedia via @livekit/react-native-webrtc is not supported on web');
+  },
+  enumerateDevices: async () => [],
+};
+
+export const registerGlobals = () => {};
+
+export default {};

--- a/src/stubs/livekit-react-native.web.ts
+++ b/src/stubs/livekit-react-native.web.ts
@@ -1,0 +1,20 @@
+export const registerGlobals = () => {};
+
+export const AudioSession = {
+  startAudioSession: async () => {},
+  stopAudioSession: async () => {},
+  selectAudioOutput: async (_output?: unknown) => {},
+  setAppleAudioConfiguration: async (_config?: unknown) => {},
+  configureAudio: async (_config?: unknown) => {},
+  getAudioOutputs: async () => [],
+};
+
+export const useRoomContext = () => {
+  throw new Error('@livekit/react-native components are not supported on web');
+};
+
+export const LiveKitRoom = () => null;
+export const VideoTrack = () => null;
+export const VideoView = () => null;
+
+export default {};

--- a/src/stubs/react-native-ble-manager.web.ts
+++ b/src/stubs/react-native-ble-manager.web.ts
@@ -1,0 +1,68 @@
+export type BleState = 'on' | 'off' | 'turning_on' | 'turning_off' | 'unknown' | 'unauthorized' | 'resetting' | 'unsupported';
+
+export interface Peripheral {
+  id: string;
+  name?: string | null;
+  rssi?: number;
+  advertising?: {
+    isConnectable?: boolean;
+    serviceUUIDs?: string[];
+    manufacturerData?: any;
+    serviceData?: any;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+export interface BleManagerDidUpdateValueForCharacteristicEvent {
+  value: number[];
+  peripheral: string;
+  service: string;
+  characteristic: string;
+}
+
+export enum BleScanCallbackType {
+  AllMatches = 1,
+  FirstMatch = 2,
+  MatchLost = 4,
+}
+
+export enum BleScanMatchMode {
+  Aggressive = 1,
+  Sticky = 2,
+}
+
+export enum BleScanMode {
+  Opportunistic = -1,
+  LowPower = 0,
+  Balanced = 1,
+  LowLatency = 2,
+}
+
+const notSupported = () => Promise.reject(new Error('Bluetooth is not supported on web'));
+const noopAsync = () => Promise.resolve();
+const emptyListener = { remove: () => {} };
+
+const BleManager = {
+  start: noopAsync,
+  checkState: () => Promise.resolve('unknown' as BleState),
+  scan: noopAsync,
+  stopScan: noopAsync,
+  connect: notSupported,
+  disconnect: noopAsync,
+  getConnectedPeripherals: () => Promise.resolve([] as Peripheral[]),
+  getDiscoveredPeripherals: () => Promise.resolve([] as Peripheral[]),
+  retrieveServices: notSupported,
+  startNotification: notSupported,
+  stopNotification: notSupported,
+  read: notSupported,
+  write: notSupported,
+  writeWithoutResponse: notSupported,
+  onDidUpdateState: () => emptyListener,
+  onDidUpdateValueForCharacteristic: () => emptyListener,
+  onDisconnectPeripheral: () => emptyListener,
+  onDiscoverPeripheral: () => emptyListener,
+  onStopScan: () => emptyListener,
+};
+
+export default BleManager;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,6 +2741,51 @@
     web-streams-polyfill "^4.1.0"
     well-known-symbols "^4.1.0"
 
+"@mapbox/geojson-rewind@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
+  integrity sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==
+  dependencies:
+    get-stream "^6.0.1"
+    minimist "^1.2.6"
+
+"@mapbox/jsonlint-lines-primitives@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz#7d7b0b971fbaf6d60953272db4df03020d3fb004"
+  integrity sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==
+
+"@mapbox/mapbox-gl-supported@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz#c15367178d8bfe4765e6b47b542fe821ce259c7b"
+  integrity sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==
+
+"@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+  integrity sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==
+
+"@mapbox/tiny-sdf@^2.0.6":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz#95dae0dc371b8c55c53d70f3e25d56823427f4c8"
+  integrity sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==
+
+"@mapbox/unitbezier@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz#d32deb66c7177e9e9dfc3bbd697083e2e657ff01"
+  integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
+
+"@mapbox/vector-tile@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
+  integrity sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==
+  dependencies:
+    "@mapbox/point-geometry" "~0.1.0"
+
+"@mapbox/whoots-js@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
+  integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
+
 "@microsoft/signalr@~8.0.7":
   version "8.0.7"
   resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-8.0.7.tgz#94419ddbf9418753e493f4ae4c13990316ec2ea5"
@@ -6597,6 +6642,11 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
 
+csscolorparser@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz#b34f391eea4da8f3e98231e2ccd8df9c041f171b"
+  integrity sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -6997,6 +7047,11 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
+
+earcut@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
+  integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -8447,6 +8502,11 @@ geojson-rbush@3.x:
     "@types/geojson" "7946.0.8"
     rbush "^3.0.1"
 
+geojson-vt@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
+  integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
+
 geojson@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
@@ -8496,7 +8556,7 @@ get-proto@^1.0.0, get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -8548,6 +8608,11 @@ github-url-from-git@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz#f985fedcc0a9aa579dc88d7aff068d55cc6251a0"
   integrity sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ==
+
+gl-matrix@^3.4.3:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.4.tgz#7789ee4982f62c7a7af447ee488f3bd6b0c77003"
+  integrity sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -8678,6 +8743,11 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+grid-index@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/grid-index/-/grid-index-1.1.0.tgz#97f8221edec1026c8377b86446a7c71e79522ea7"
+  integrity sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==
 
 handlebars@^4.7.8:
   version "4.7.8"
@@ -8924,7 +8994,7 @@ iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.13, ieee754@^1.2.1:
+ieee754@^1.1.12, ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -10326,6 +10396,11 @@ jsonparse@^1.2.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+kdbush@^4.0.1, kdbush@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-4.1.0.tgz#d504bc0447a59be4fb75533a5c25e316b3ed8859"
+  integrity sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -10864,6 +10939,34 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+mapbox-gl@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-2.15.0.tgz#9439828d0bae1e7b464ae08b30cb2e65a7e2256d"
+  integrity sha512-fjv+aYrd5TIHiL7wRa+W7KjtUqKWziJMZUkK5hm8TvJ3OLeNPx4NmW/DgfYhd/jHej8wWL+QJBDbdMMAKvNC0A==
+  dependencies:
+    "@mapbox/geojson-rewind" "^0.5.2"
+    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
+    "@mapbox/mapbox-gl-supported" "^2.0.1"
+    "@mapbox/point-geometry" "^0.1.0"
+    "@mapbox/tiny-sdf" "^2.0.6"
+    "@mapbox/unitbezier" "^0.0.1"
+    "@mapbox/vector-tile" "^1.3.1"
+    "@mapbox/whoots-js" "^3.1.0"
+    csscolorparser "~1.0.3"
+    earcut "^2.2.4"
+    geojson-vt "^3.2.1"
+    gl-matrix "^3.4.3"
+    grid-index "^1.1.0"
+    kdbush "^4.0.1"
+    murmurhash-js "^1.0.0"
+    pbf "^3.2.1"
+    potpack "^2.0.0"
+    quickselect "^2.0.0"
+    rw "^1.3.3"
+    supercluster "^8.0.0"
+    tinyqueue "^2.0.3"
+    vt-pbf "^3.1.3"
 
 marky@^1.2.2:
   version "1.3.0"
@@ -11465,6 +11568,11 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+murmurhash-js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
+  integrity sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -12229,6 +12337,14 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pbf@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.3.0.tgz#1790f3d99118333cc7f498de816028a346ef367f"
+  integrity sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==
+  dependencies:
+    ieee754 "^1.1.12"
+    resolve-protobuf-schema "^2.1.0"
+
 peek-readable@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
@@ -12422,6 +12538,11 @@ postinstall-postinstall@^2.1.0:
   resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
   integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
+potpack@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/potpack/-/potpack-2.1.0.tgz#fe548e2f9061e9937f17191c1ab6dd98ca30e02f"
+  integrity sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -12523,6 +12644,11 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
+
+protocol-buffers-schema@^3.3.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz#fd9a58a5c4e96385b964808f3ddd58f9ef18c3c8"
+  integrity sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==
 
 proxy-from-env@^1.1.0:
   version "1.1.0"
@@ -13259,6 +13385,13 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
+resolve-protobuf-schema@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz#9ca9a9e69cf192bbdaf1006ec1973948aa4a3758"
+  integrity sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==
+  dependencies:
+    protocol-buffers-schema "^3.3.1"
+
 resolve-workspace-root@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-workspace-root/-/resolve-workspace-root-2.0.0.tgz#a0098daa0067cd0efa6eb525c57c8fb4a61e78f8"
@@ -13368,6 +13501,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rw@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 rxjs@7.8.2, rxjs@^7.5.2, rxjs@^7.8.1:
   version "7.8.2"
@@ -14231,6 +14369,13 @@ sucrase@~3.35.1:
     tinyglobby "^0.2.11"
     ts-interface-checker "^0.1.9"
 
+supercluster@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-8.0.1.tgz#9946ba123538e9e9ab15de472531f604e7372df5"
+  integrity sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==
+  dependencies:
+    kdbush "^4.0.2"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -14480,6 +14625,11 @@ tinyglobby@^0.2.13:
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
+
+tinyqueue@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
+  integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -15027,6 +15177,15 @@ void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
+
+vt-pbf@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.3.tgz#68fd150756465e2edae1cc5c048e063916dcfaac"
+  integrity sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==
+  dependencies:
+    "@mapbox/point-geometry" "0.1.0"
+    "@mapbox/vector-tile" "^1.3.1"
+    pbf "^3.2.1"
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR addresses two main issues: web platform compatibility fixes and an iOS voice freeze bug.

### iOS Voice Freeze Fix
Replaces `expo-audio` permission handling with `react-native-permissions` in the LiveKit store. The `expo-audio` permission request activates `AVAudioSession` on iOS, which deadlocks against the active `expo-av` session and freezes the app. All permission checks and requests in both `requestPermissions` and `connectToRoom` flows now use `react-native-permissions` (`check`/`request`). Corresponding unit tests have been updated to reflect the new permission API.

### Web Platform Fixes
- **Module stubs**: Adds web stubs for native-only modules (`react-native-ble-manager`, `@livekit/react-native`, `@livekit/react-native-webrtc`, `countly-sdk-react-native-bridge`) and configures Metro's resolver to use them on the web platform, preventing build failures from native dependencies.
- **Zustand resolution**: Forces zustand to resolve to its CJS build on web to avoid `import.meta.env` errors from its ESM build.
- **UI component style props**: Strips the `style` prop from web implementations of Box, Card, Center, Grid, GridItem, Heading, HStack, VStack, Skeleton, SkeletonText, and Text to prevent incompatible React Native style objects from being passed to HTML elements.
- **Audio stream bottom sheet**: Replaces the native `Select` dropdown with a custom scrollable list of pressable options for stream selection, improving web compatibility.
- **Static map**: Adds a web-specific static map component using Mapbox with HTML-based markers and overlays.

### CI/CD
- Updates release notes generation to replace "PR" with "Release" in the published notes.
<!-- kody-pr-summary:end -->