### PR TITLE
RG-T117 chat feature flag

### DIFF
--- a/src/api/feature-flags/feature-flags.ts
+++ b/src/api/feature-flags/feature-flags.ts
@@ -1,0 +1,37 @@
+import { api } from '../common/client';
+
+const FEATURE_TOGGLES = '/FeatureToggles';
+
+// ---------------------------------------------------------------------------
+// Feature toggle evaluation (department-scoped, any authenticated user).
+// Backed by the v4 FeatureToggles API; keys live in Resgrid.Model.FeatureFlagKeys.
+// ---------------------------------------------------------------------------
+
+export interface FeatureToggleData {
+  Key: string;
+  Enabled: boolean;
+  Value?: string | null;
+  ValueType?: string | null;
+  Source?: string | null;
+}
+
+export interface FeatureTogglesResult {
+  Data?: FeatureToggleData[];
+  StateHash?: string;
+}
+
+export interface FeatureToggleResult {
+  Data?: FeatureToggleData;
+}
+
+/** Evaluates every active flag for the caller's department. */
+export const getAllFeatureFlags = async (signal?: AbortSignal) => {
+  const response = await api.get<FeatureTogglesResult>(`${FEATURE_TOGGLES}/GetAll`, { signal });
+  return response.data;
+};
+
+/** Lightweight enabled-only check for a single flag. */
+export const getFeatureFlagState = async (key: string, signal?: AbortSignal) => {
+  const response = await api.get<FeatureToggleResult>(`${FEATURE_TOGGLES}/GetState`, { params: { key }, signal });
+  return response.data;
+};

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -34,6 +34,7 @@ import { usePushNotifications } from '@/services/push-notification';
 import { useCoreStore } from '@/stores/app/core-store';
 import { useCalendarStore } from '@/stores/calendar/store';
 import { useCallsStore } from '@/stores/calls/store';
+import { FeatureFlagKeys, featureFlagsStore } from '@/stores/feature-flags/store';
 import { usePersonnelStore } from '@/stores/personnel/store';
 import { useRolesStore } from '@/stores/roles/store';
 import { securityStore } from '@/stores/security/store';
@@ -100,20 +101,28 @@ export default function TabLayout() {
       //await useShiftsStore.getState().init();
       //await usePersonnelStore.getState().init();
       await securityStore.getState().getRights();
+      await featureFlagsStore.getState().fetchFlags();
 
       //await useSignalRStore.getState().connectUpdateHub();
       //await useSignalRStore.getState().connectGeolocationHub();
 
-      // Connect the realtime chat hub (best-effort; chat may be disabled per department)
-      try {
-        await useSignalRStore.getState().connectChatHub();
+      // Connect the realtime chat hub only when the Chat.System feature flag is on for
+      // this department; when it is off every chat surface stays hidden.
+      if (featureFlagsStore.getState().isEnabled(FeatureFlagKeys.ChatSystem)) {
+        try {
+          await useSignalRStore.getState().connectChatHub();
+          logger.info({
+            message: 'SignalR chat hub connected successfully',
+          });
+        } catch (error) {
+          logger.error({
+            message: 'Failed to connect SignalR chat hub during initialization',
+            context: { error },
+          });
+        }
+      } else {
         logger.info({
-          message: 'SignalR chat hub connected successfully',
-        });
-      } catch (error) {
-        logger.error({
-          message: 'Failed to connect SignalR chat hub during initialization',
-          context: { error },
+          message: 'Chat disabled by feature flag; skipping chat hub connection',
         });
       }
 

--- a/src/app/(app)/chat.tsx
+++ b/src/app/(app)/chat.tsx
@@ -1,4 +1,4 @@
-import { type Href, Stack, useFocusEffect, useRouter } from 'expo-router';
+import { type Href, Redirect, Stack, useFocusEffect, useRouter } from 'expo-router';
 import { Bot, MessageCircle, MessagesSquare, Network, Plus, Sparkles, Users } from 'lucide-react-native';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +19,7 @@ import { Text } from '@/components/ui/text';
 import { VStack } from '@/components/ui/vstack';
 import { type ChatChannelResultData, ChatChannelType } from '@/models/v4/chat';
 import { useChatStore } from '@/stores/chat/store';
+import { useIsChatEnabled } from '@/stores/feature-flags/store';
 
 function ChannelRow({ channel, onPress }: { channel: ChatChannelResultData; onPress: () => void }) {
   const { t } = useTranslation();
@@ -81,6 +82,7 @@ function Section({ title, channels, onOpen }: { title: string; channels: ChatCha
 export default function ChatScreen() {
   const { t } = useTranslation();
   const router = useRouter();
+  const isChatEnabled = useIsChatEnabled();
   const channels = useChatStore((s) => s.channels);
   const isLoading = useChatStore((s) => s.isLoadingChannels);
   const pendingAcks = useChatStore((s) => s.pendingAcks);
@@ -89,9 +91,10 @@ export default function ChatScreen() {
 
   useFocusEffect(
     useCallback(() => {
+      if (!isChatEnabled) return;
       useChatStore.getState().fetchChannels();
       useChatStore.getState().fetchPendingAcks();
-    }, [])
+    }, [isChatEnabled])
   );
 
   const grouped = groupChannels(channels);
@@ -102,6 +105,11 @@ export default function ChatScreen() {
     },
     [router]
   );
+
+  // Chat.System feature flag off: no chat for this department.
+  if (!isChatEnabled) {
+    return <Redirect href="/(app)/home" />;
+  }
 
   return (
     <Box className="size-full flex-1 bg-background-0">

--- a/src/app/(app)/chat.tsx
+++ b/src/app/(app)/chat.tsx
@@ -15,11 +15,12 @@ import { Fab, FabIcon } from '@/components/ui/fab';
 import { FocusAwareStatusBar } from '@/components/ui/focus-aware-status-bar';
 import { HStack } from '@/components/ui/hstack';
 import { Pressable } from '@/components/ui/pressable';
+import { Spinner } from '@/components/ui/spinner';
 import { Text } from '@/components/ui/text';
 import { VStack } from '@/components/ui/vstack';
 import { type ChatChannelResultData, ChatChannelType } from '@/models/v4/chat';
 import { useChatStore } from '@/stores/chat/store';
-import { useIsChatEnabled } from '@/stores/feature-flags/store';
+import { useChatSystemStatus } from '@/stores/feature-flags/store';
 
 function ChannelRow({ channel, onPress }: { channel: ChatChannelResultData; onPress: () => void }) {
   const { t } = useTranslation();
@@ -82,7 +83,8 @@ function Section({ title, channels, onOpen }: { title: string; channels: ChatCha
 export default function ChatScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const isChatEnabled = useIsChatEnabled();
+  const chatStatus = useChatSystemStatus();
+  const isChatEnabled = chatStatus === 'enabled';
   const channels = useChatStore((s) => s.channels);
   const isLoading = useChatStore((s) => s.isLoadingChannels);
   const pendingAcks = useChatStore((s) => s.pendingAcks);
@@ -106,8 +108,19 @@ export default function ChatScreen() {
     [router]
   );
 
+  // Chat.System flag not yet resolved: wait instead of redirecting away from a valid route.
+  if (chatStatus === 'unknown') {
+    return (
+      <Box className="size-full flex-1 items-center justify-center bg-background-0">
+        <Stack.Screen options={{ headerShown: false }} />
+        <FocusAwareStatusBar />
+        <Spinner />
+      </Box>
+    );
+  }
+
   // Chat.System feature flag off: no chat for this department.
-  if (!isChatEnabled) {
+  if (chatStatus === 'disabled') {
     return <Redirect href="/(app)/home" />;
   }
 

--- a/src/app/(app)/chatbot.tsx
+++ b/src/app/(app)/chatbot.tsx
@@ -1,4 +1,4 @@
-import { Stack, useFocusEffect } from 'expo-router';
+import { Redirect, Stack, useFocusEffect } from 'expo-router';
 import { RefreshCw, Send, Sparkles } from 'lucide-react-native';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,10 +19,12 @@ import { VStack } from '@/components/ui/vstack';
 import { type ChatMessageResultData } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
+import { useIsChatEnabled } from '@/stores/feature-flags/store';
 
 export default function ChatbotScreen() {
   const { t } = useTranslation();
   const currentUserId = useAuthStore((s) => s.userId);
+  const isChatEnabled = useIsChatEnabled();
   const chatbotChannelId = useChatStore((s) => s.chatbotChannelId);
   const chatbotTyping = useChatStore((s) => s.chatbotTyping);
   const messages = useChatStore((s) => (chatbotChannelId ? s.messagesByChannel[chatbotChannelId] : undefined));
@@ -30,12 +32,13 @@ export default function ChatbotScreen() {
 
   useFocusEffect(
     useCallback(() => {
+      if (!isChatEnabled) return;
       const store = useChatStore.getState();
       void store.initChatbot();
       return () => {
         useChatStore.getState().setActiveChannel(null);
       };
-    }, [])
+    }, [isChatEnabled])
   );
 
   // Keep the assistant channel active while viewing so incoming messages don't inflate unread.
@@ -60,6 +63,11 @@ export default function ChatbotScreen() {
     ),
     [currentUserId]
   );
+
+  // Chat.System feature flag off: the assistant rides on the chat system, hide it too.
+  if (!isChatEnabled) {
+    return <Redirect href="/(app)/home" />;
+  }
 
   return (
     <Box className="size-full flex-1 bg-background-0">

--- a/src/app/(app)/chatbot.tsx
+++ b/src/app/(app)/chatbot.tsx
@@ -14,17 +14,19 @@ import { HStack } from '@/components/ui/hstack';
 import { Input, InputField } from '@/components/ui/input';
 import { KeyboardAvoidingView } from '@/components/ui/keyboard-avoiding-view';
 import { Pressable } from '@/components/ui/pressable';
+import { Spinner } from '@/components/ui/spinner';
 import { Text } from '@/components/ui/text';
 import { VStack } from '@/components/ui/vstack';
 import { type ChatMessageResultData } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
-import { useIsChatEnabled } from '@/stores/feature-flags/store';
+import { useChatSystemStatus } from '@/stores/feature-flags/store';
 
 export default function ChatbotScreen() {
   const { t } = useTranslation();
   const currentUserId = useAuthStore((s) => s.userId);
-  const isChatEnabled = useIsChatEnabled();
+  const chatStatus = useChatSystemStatus();
+  const isChatEnabled = chatStatus === 'enabled';
   const chatbotChannelId = useChatStore((s) => s.chatbotChannelId);
   const chatbotTyping = useChatStore((s) => s.chatbotTyping);
   const messages = useChatStore((s) => (chatbotChannelId ? s.messagesByChannel[chatbotChannelId] : undefined));
@@ -64,8 +66,19 @@ export default function ChatbotScreen() {
     [currentUserId]
   );
 
+  // Chat.System flag not yet resolved: wait instead of redirecting away from a valid route.
+  if (chatStatus === 'unknown') {
+    return (
+      <Box className="size-full flex-1 items-center justify-center bg-background-0">
+        <Stack.Screen options={{ headerShown: false }} />
+        <FocusAwareStatusBar />
+        <Spinner />
+      </Box>
+    );
+  }
+
   // Chat.System feature flag off: the assistant rides on the chat system, hide it too.
-  if (!isChatEnabled) {
+  if (chatStatus === 'disabled') {
     return <Redirect href="/(app)/home" />;
   }
 

--- a/src/app/chat/[channelId].tsx
+++ b/src/app/chat/[channelId].tsx
@@ -1,5 +1,5 @@
 import { Image } from 'expo-image';
-import { type Href, Stack, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
+import { type Href, Redirect, Stack, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { Circle } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +27,7 @@ import { VStack } from '@/components/ui/vstack';
 import { ChatChannelType, ChatMessagePriority, type ChatMessageResultData, ChatMessageType, type GifResultData } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
+import { useIsChatEnabled } from '@/stores/feature-flags/store';
 import { securityStore } from '@/stores/security/store';
 import { useToastStore } from '@/stores/toast/store';
 
@@ -38,6 +39,7 @@ export default function ChannelConversationScreen() {
 
   const currentUserId = useAuthStore((s) => s.userId);
   const isModerator = !!securityStore((s) => s.rights)?.IsAdmin;
+  const isChatEnabled = useIsChatEnabled();
 
   const channel = useChatStore((s) => s.channels.find((c) => c.ChatChannelId === channelId));
   const messages = useChatStore((s) => (channelId ? s.messagesByChannel[channelId] : undefined));
@@ -64,7 +66,7 @@ export default function ChannelConversationScreen() {
   // Mount: activate channel, join hub, load history and members.
   useFocusEffect(
     useCallback(() => {
-      if (!channelId) return;
+      if (!channelId || !isChatEnabled) return;
       const store = useChatStore.getState();
       store.setActiveChannel(channelId);
       void store.joinChannel(channelId);
@@ -73,7 +75,7 @@ export default function ChannelConversationScreen() {
       return () => {
         useChatStore.getState().setActiveChannel(null);
       };
-    }, [channelId])
+    }, [channelId, isChatEnabled])
   );
 
   // Fetch presence for the channel members (for the header online dot).
@@ -235,6 +237,11 @@ export default function ChannelConversationScreen() {
   }, [channelId]);
 
   const title = channel ? getChannelDisplayName(channel, t) : t('chat.title');
+
+  // Chat.System feature flag off: block deep links (push notifications, stale routes).
+  if (!isChatEnabled) {
+    return <Redirect href="/(app)/home" />;
+  }
 
   return (
     <Box className="size-full flex-1 bg-background-0">

--- a/src/app/chat/[channelId].tsx
+++ b/src/app/chat/[channelId].tsx
@@ -27,7 +27,7 @@ import { VStack } from '@/components/ui/vstack';
 import { ChatChannelType, ChatMessagePriority, type ChatMessageResultData, ChatMessageType, type GifResultData } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
-import { useIsChatEnabled } from '@/stores/feature-flags/store';
+import { useChatSystemStatus } from '@/stores/feature-flags/store';
 import { securityStore } from '@/stores/security/store';
 import { useToastStore } from '@/stores/toast/store';
 
@@ -39,7 +39,8 @@ export default function ChannelConversationScreen() {
 
   const currentUserId = useAuthStore((s) => s.userId);
   const isModerator = !!securityStore((s) => s.rights)?.IsAdmin;
-  const isChatEnabled = useIsChatEnabled();
+  const chatStatus = useChatSystemStatus();
+  const isChatEnabled = chatStatus === 'enabled';
 
   const channel = useChatStore((s) => s.channels.find((c) => c.ChatChannelId === channelId));
   const messages = useChatStore((s) => (channelId ? s.messagesByChannel[channelId] : undefined));
@@ -238,8 +239,18 @@ export default function ChannelConversationScreen() {
 
   const title = channel ? getChannelDisplayName(channel, t) : t('chat.title');
 
+  // Chat.System flag not yet resolved: wait instead of redirecting away from a valid deep link.
+  if (chatStatus === 'unknown') {
+    return (
+      <Box className="size-full flex-1 items-center justify-center bg-background-0">
+        <Stack.Screen options={{ title, headerShown: true, headerBackTitle: '' }} />
+        <Spinner />
+      </Box>
+    );
+  }
+
   // Chat.System feature flag off: block deep links (push notifications, stale routes).
-  if (!isChatEnabled) {
+  if (chatStatus === 'disabled') {
     return <Redirect href="/(app)/home" />;
   }
 

--- a/src/app/chat/thread/[messageId].tsx
+++ b/src/app/chat/thread/[messageId].tsx
@@ -10,13 +10,14 @@ import { Box } from '@/components/ui/box';
 import { Divider } from '@/components/ui/divider';
 import { FlatList } from '@/components/ui/flat-list';
 import { KeyboardAvoidingView } from '@/components/ui/keyboard-avoiding-view';
+import { Spinner } from '@/components/ui/spinner';
 import { Text } from '@/components/ui/text';
 import { VStack } from '@/components/ui/vstack';
 import { logger } from '@/lib/logging';
 import { ChatMessagePriority, type ChatMessageResultData, ChatMessageType } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
-import { useIsChatEnabled } from '@/stores/feature-flags/store';
+import { useChatSystemStatus } from '@/stores/feature-flags/store';
 
 export default function ThreadScreen() {
   const { t } = useTranslation();
@@ -25,7 +26,8 @@ export default function ThreadScreen() {
   const channelId = Array.isArray(params.channelId) ? params.channelId[0] : params.channelId;
 
   const currentUserId = useAuthStore((s) => s.userId);
-  const isChatEnabled = useIsChatEnabled();
+  const chatStatus = useChatSystemStatus();
+  const isChatEnabled = chatStatus === 'enabled';
   const channelMessages = useChatStore((s) => (channelId ? s.messagesByChannel[channelId] : undefined));
   const [fetchedReplies, setFetchedReplies] = useState<ChatMessageResultData[]>([]);
 
@@ -96,8 +98,18 @@ export default function ThreadScreen() {
     [currentUserId, channelId]
   );
 
+  // Chat.System flag not yet resolved: wait instead of redirecting away from a valid deep link.
+  if (chatStatus === 'unknown') {
+    return (
+      <Box className="size-full flex-1 items-center justify-center bg-background-0">
+        <Stack.Screen options={{ title: t('chat.thread'), headerShown: true, headerBackTitle: '' }} />
+        <Spinner />
+      </Box>
+    );
+  }
+
   // Chat.System feature flag off: block deep links into threads.
-  if (!isChatEnabled) {
+  if (chatStatus === 'disabled') {
     return <Redirect href="/(app)/home" />;
   }
 

--- a/src/app/chat/thread/[messageId].tsx
+++ b/src/app/chat/thread/[messageId].tsx
@@ -1,4 +1,4 @@
-import { Stack, useLocalSearchParams } from 'expo-router';
+import { Redirect, Stack, useLocalSearchParams } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Platform } from 'react-native';
@@ -16,6 +16,7 @@ import { logger } from '@/lib/logging';
 import { ChatMessagePriority, type ChatMessageResultData, ChatMessageType } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
+import { useIsChatEnabled } from '@/stores/feature-flags/store';
 
 export default function ThreadScreen() {
   const { t } = useTranslation();
@@ -24,17 +25,18 @@ export default function ThreadScreen() {
   const channelId = Array.isArray(params.channelId) ? params.channelId[0] : params.channelId;
 
   const currentUserId = useAuthStore((s) => s.userId);
+  const isChatEnabled = useIsChatEnabled();
   const channelMessages = useChatStore((s) => (channelId ? s.messagesByChannel[channelId] : undefined));
   const [fetchedReplies, setFetchedReplies] = useState<ChatMessageResultData[]>([]);
 
   const root = useMemo(() => (channelMessages ?? []).find((m) => m.ChatMessageId === messageId), [channelMessages, messageId]);
 
   useEffect(() => {
-    if (!messageId) return;
+    if (!messageId || !isChatEnabled) return;
     getThread(messageId, undefined, 50)
       .then((response) => setFetchedReplies(response.Data ?? []))
       .catch((error) => logger.error({ message: 'chat: failed to load thread', context: { error, messageId } }));
-  }, [messageId]);
+  }, [messageId, isChatEnabled]);
 
   // Merge fetched replies with any realtime/optimistic replies already in the channel cache.
   const replies = useMemo(() => {
@@ -93,6 +95,11 @@ export default function ThreadScreen() {
     ),
     [currentUserId, channelId]
   );
+
+  // Chat.System feature flag off: block deep links into threads.
+  if (!isChatEnabled) {
+    return <Redirect href="/(app)/home" />;
+  }
 
   return (
     <Box className="size-full flex-1 bg-background-0">

--- a/src/components/sidebar/side-menu-content.tsx
+++ b/src/components/sidebar/side-menu-content.tsx
@@ -37,6 +37,7 @@ import { useAuthStore } from '@/lib/auth';
 import { getAvatarUrl } from '@/lib/utils';
 import { useAudioStreamStore } from '@/stores/app/audio-stream-store';
 import { useLiveKitStore } from '@/stores/app/livekit-store';
+import { useIsChatEnabled } from '@/stores/feature-flags/store';
 import { securityStore } from '@/stores/security/store';
 
 import { AudioStreamBottomSheet } from '../audio-stream/audio-stream-bottom-sheet';
@@ -65,6 +66,7 @@ export const SideMenu: React.FC<SideMenuProps> = React.memo(({ onNavigate }) => 
   const isPlaying = useAudioStreamStore((state) => state.isPlaying);
   const setAudioStreamBottomSheetVisible = useAudioStreamStore((state) => state.setIsBottomSheetVisible);
   const rights = securityStore((state) => state.rights);
+  const isChatEnabled = useIsChatEnabled();
 
   const menuItems: MenuItem[] = useMemo(
     () => [
@@ -152,8 +154,9 @@ export const SideMenu: React.FC<SideMenuProps> = React.memo(({ onNavigate }) => 
         route: '/(app)/settings',
         testID: 'side-menu-settings',
       },
-    ],
-    [t]
+      // Chat and the assistant are gated by the Chat.System feature flag.
+    ].filter((item) => (item.id === 'chat' || item.id === 'assistant' ? isChatEnabled : true)),
+    [t, isChatEnabled]
   );
 
   const handleNavigation = useCallback(

--- a/src/stores/feature-flags/__tests__/store.test.ts
+++ b/src/stores/feature-flags/__tests__/store.test.ts
@@ -1,0 +1,255 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { FeatureFlagKeys, featureFlagsStore, useChatSystemStatus } from '../store';
+
+// Mock the API
+jest.mock('@/api/feature-flags/feature-flags', () => ({
+  getAllFeatureFlags: jest.fn(),
+}));
+
+// Mock logging
+jest.mock('@/lib/logging', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Capture the reset callback registered at module load (var: assigned inside the hoisted
+// mock factory during import, and immune to jest.clearAllMocks unlike jest.fn call records).
+// eslint-disable-next-line no-var
+var mockFeatureFlagsResetFn: (() => void) | undefined;
+jest.mock('@/lib/storage/clear-all-data', () => ({
+  registerStoreReset: (_name: string, fn: () => void) => {
+    mockFeatureFlagsResetFn = fn;
+  },
+}));
+
+// Mock the storage
+jest.mock('../../../lib/storage', () => ({
+  zustandStorage: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+// Mock identity sources
+jest.mock('../../auth/store', () => ({
+  __esModule: true,
+  default: {
+    getState: jest.fn(),
+  },
+}));
+
+jest.mock('../../security/store', () => ({
+  securityStore: {
+    getState: jest.fn(),
+  },
+}));
+
+const { getAllFeatureFlags } = require('@/api/feature-flags/feature-flags');
+const useAuthStore = require('../../auth/store').default;
+const { securityStore } = require('../../security/store');
+
+const setIdentity = (userId: string | null, departmentId: string | null) => {
+  useAuthStore.getState.mockReturnValue({ userId });
+  securityStore.getState.mockReturnValue({
+    rights: departmentId ? { DepartmentId: departmentId } : null,
+  });
+};
+
+describe('Feature Flags Store', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    featureFlagsStore.setState({
+      flags: {},
+      isLoaded: false,
+      error: null,
+      identityKey: null,
+    });
+    setIdentity('user-1', 'dept-1');
+  });
+
+  describe('fetchFlags', () => {
+    it('should store flags and stamp the current identity on success', async () => {
+      getAllFeatureFlags.mockResolvedValue({
+        Data: [{ Key: FeatureFlagKeys.ChatSystem, Enabled: true, Value: null }],
+      });
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      const state = featureFlagsStore.getState();
+      expect(state.flags[FeatureFlagKeys.ChatSystem]).toEqual({ enabled: true, value: null });
+      expect(state.isLoaded).toBe(true);
+      expect(state.error).toBeNull();
+      expect(state.identityKey).toBe('user-1:dept-1');
+    });
+
+    it('should keep persisted flags on failure for the same identity', async () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        identityKey: 'user-1:dept-1',
+      });
+      getAllFeatureFlags.mockRejectedValue(new Error('network down'));
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      const state = featureFlagsStore.getState();
+      expect(state.flags[FeatureFlagKeys.ChatSystem]?.enabled).toBe(true);
+      expect(state.identityKey).toBe('user-1:dept-1');
+      expect(state.error).toBe('network down');
+    });
+
+    it('should clear flags from a different department before fetching so a failed fetch cannot reuse them', async () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        identityKey: 'user-1:dept-old',
+      });
+      getAllFeatureFlags.mockRejectedValue(new Error('network down'));
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      const state = featureFlagsStore.getState();
+      expect(state.flags).toEqual({});
+      // Fail-closed: the failed fetch still resolves the flags so consumers stop waiting.
+      expect(state.isLoaded).toBe(true);
+      expect(state.identityKey).toBeNull();
+    });
+
+    it('should clear flags from a different account before fetching', async () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        identityKey: 'user-other:dept-1',
+      });
+      getAllFeatureFlags.mockRejectedValue(new Error('network down'));
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      expect(featureFlagsStore.getState().flags).toEqual({});
+    });
+
+    it('should replace another identity flags with fresh ones on success', async () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        identityKey: 'user-other:dept-other',
+      });
+      getAllFeatureFlags.mockResolvedValue({
+        Data: [{ Key: FeatureFlagKeys.ChatSystem, Enabled: false, Value: null }],
+      });
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      const state = featureFlagsStore.getState();
+      expect(state.flags[FeatureFlagKeys.ChatSystem]?.enabled).toBe(false);
+      expect(state.identityKey).toBe('user-1:dept-1');
+    });
+
+    it('should keep flags on failure when department is unknown but the user matches', async () => {
+      setIdentity('user-1', null);
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        identityKey: 'user-1:dept-1',
+      });
+      getAllFeatureFlags.mockRejectedValue(new Error('network down'));
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      const state = featureFlagsStore.getState();
+      expect(state.flags[FeatureFlagKeys.ChatSystem]?.enabled).toBe(true);
+      expect(state.identityKey).toBe('user-1:dept-1');
+    });
+
+    it('should clear flags when department is unknown and the user differs', async () => {
+      setIdentity('user-2', null);
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        identityKey: 'user-1:dept-1',
+      });
+      getAllFeatureFlags.mockRejectedValue(new Error('network down'));
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      expect(featureFlagsStore.getState().flags).toEqual({});
+    });
+  });
+
+  describe('useChatSystemStatus', () => {
+    it('should be unknown before the initial fetch resolves', () => {
+      const { result } = renderHook(() => useChatSystemStatus());
+
+      expect(result.current).toBe('unknown');
+    });
+
+    it('should report enabled and disabled from the flag entry', () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+      });
+      const { result: enabled } = renderHook(() => useChatSystemStatus());
+      expect(enabled.current).toBe('enabled');
+
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: false, value: null } },
+      });
+      const { result: disabled } = renderHook(() => useChatSystemStatus());
+      expect(disabled.current).toBe('disabled');
+    });
+
+    it('should resolve disabled when flags loaded without an entry', () => {
+      featureFlagsStore.setState({ flags: {}, isLoaded: true });
+
+      const { result } = renderHook(() => useChatSystemStatus());
+
+      expect(result.current).toBe('disabled');
+    });
+
+    it('should resolve disabled (fail-closed) after a failed fetch with no persisted flags', async () => {
+      getAllFeatureFlags.mockRejectedValue(new Error('network down'));
+
+      await featureFlagsStore.getState().fetchFlags();
+
+      const { result } = renderHook(() => useChatSystemStatus());
+      expect(result.current).toBe('disabled');
+    });
+  });
+
+  describe('logout reset', () => {
+    it('should clear flags, resolution and identity so the next session fails closed', () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+        isLoaded: true,
+        error: 'previous error',
+        identityKey: 'user-1:dept-1',
+      });
+
+      expect(mockFeatureFlagsResetFn).toBeDefined();
+      mockFeatureFlagsResetFn?.();
+
+      const state = featureFlagsStore.getState();
+      expect(state.flags).toEqual({});
+      expect(state.isLoaded).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.identityKey).toBeNull();
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('should return the flag state when present and the default when missing', () => {
+      featureFlagsStore.setState({
+        flags: { [FeatureFlagKeys.ChatSystem]: { enabled: true, value: null } },
+      });
+
+      expect(featureFlagsStore.getState().isEnabled(FeatureFlagKeys.ChatSystem)).toBe(true);
+      expect(featureFlagsStore.getState().isEnabled('Unknown.Flag')).toBe(false);
+      expect(featureFlagsStore.getState().isEnabled('Unknown.Flag', true)).toBe(true);
+    });
+  });
+});

--- a/src/stores/feature-flags/store.ts
+++ b/src/stores/feature-flags/store.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import { getAllFeatureFlags } from '@/api/feature-flags/feature-flags';
+import { logger } from '@/lib/logging';
+
+import { zustandStorage } from '../../lib/storage';
+
+// Well-known feature flag keys. Keep values in sync with Resgrid.Model.FeatureFlagKeys.
+export const FeatureFlagKeys = {
+  ChatSystem: 'Chat.System',
+} as const;
+
+export type FeatureFlagKey = (typeof FeatureFlagKeys)[keyof typeof FeatureFlagKeys];
+
+interface FeatureFlagEntry {
+  enabled: boolean;
+  value?: string | null;
+}
+
+export interface FeatureFlagsState {
+  flags: Record<string, FeatureFlagEntry>;
+  isLoaded: boolean;
+  error: string | null;
+  fetchFlags: () => Promise<void>;
+  isEnabled: (key: string, defaultValue?: boolean) => boolean;
+}
+
+export const featureFlagsStore = create<FeatureFlagsState>()(
+  persist(
+    (set, get) => ({
+      flags: {},
+      isLoaded: false,
+      error: null,
+      fetchFlags: async () => {
+        try {
+          const response = await getAllFeatureFlags();
+          const flags: Record<string, FeatureFlagEntry> = {};
+          for (const flag of response?.Data ?? []) {
+            if (flag?.Key) {
+              flags[flag.Key] = { enabled: !!flag.Enabled, value: flag.Value ?? null };
+            }
+          }
+          set({ flags, isLoaded: true, error: null });
+        } catch (error) {
+          // Keep any persisted flags on failure so gating stays stable while offline.
+          logger.error({
+            message: 'Failed to fetch feature flags',
+            context: { error },
+          });
+          set({ error: error instanceof Error ? error.message : 'Failed to fetch feature flags' });
+        }
+      },
+      isEnabled: (key: string, defaultValue = false) => get().flags[key]?.enabled ?? defaultValue,
+    }),
+    {
+      name: 'feature-flags-storage',
+      storage: createJSONStorage(() => zustandStorage),
+    }
+  )
+);
+
+// Reactive hook; components re-render when the flag changes. Unknown flags default to disabled
+// so gated features stay hidden until the server confirms them.
+export const useFeatureFlag = (key: string, defaultValue = false) => featureFlagsStore((state) => state.flags[key]?.enabled ?? defaultValue);
+
+export const useIsChatEnabled = () => useFeatureFlag(FeatureFlagKeys.ChatSystem);

--- a/src/stores/feature-flags/store.ts
+++ b/src/stores/feature-flags/store.ts
@@ -3,8 +3,11 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { getAllFeatureFlags } from '@/api/feature-flags/feature-flags';
 import { logger } from '@/lib/logging';
+import { registerStoreReset } from '@/lib/storage/clear-all-data';
 
 import { zustandStorage } from '../../lib/storage';
+import useAuthStore from '../auth/store';
+import { securityStore } from '../security/store';
 
 // Well-known feature flag keys. Keep values in sync with Resgrid.Model.FeatureFlagKeys.
 export const FeatureFlagKeys = {
@@ -18,10 +21,38 @@ interface FeatureFlagEntry {
   value?: string | null;
 }
 
+// Immutable ids only (user id + department id) so renames/code changes never alias identities.
+const getCurrentIdentityKey = (): string | null => {
+  const userId = useAuthStore.getState().userId;
+  const departmentId = securityStore.getState().rights?.DepartmentId;
+  if (!userId || !departmentId) {
+    return null;
+  }
+  return `${userId}:${departmentId}`;
+};
+
+// True only when the persisted flags provably belong to a different account/department.
+// With no proof (e.g. rights unavailable offline) flags are kept so gating stays stable.
+const isPersistedIdentityStale = (persistedKey: string | null): boolean => {
+  if (!persistedKey) {
+    return false;
+  }
+  const userId = useAuthStore.getState().userId;
+  const departmentId = securityStore.getState().rights?.DepartmentId;
+  if (userId && departmentId) {
+    return persistedKey !== `${userId}:${departmentId}`;
+  }
+  if (userId) {
+    return !persistedKey.startsWith(`${userId}:`);
+  }
+  return false;
+};
+
 export interface FeatureFlagsState {
   flags: Record<string, FeatureFlagEntry>;
   isLoaded: boolean;
   error: string | null;
+  identityKey: string | null;
   fetchFlags: () => Promise<void>;
   isEnabled: (key: string, defaultValue?: boolean) => boolean;
 }
@@ -32,7 +63,14 @@ export const featureFlagsStore = create<FeatureFlagsState>()(
       flags: {},
       isLoaded: false,
       error: null,
+      identityKey: null,
       fetchFlags: async () => {
+        const identityKey = getCurrentIdentityKey();
+        if (isPersistedIdentityStale(get().identityKey)) {
+          // Persisted flags belong to another account/department; drop them before fetching
+          // so a failed fetch can never gate this identity with the previous one's flags.
+          set({ flags: {}, isLoaded: false, identityKey: null });
+        }
         try {
           const response = await getAllFeatureFlags();
           const flags: Record<string, FeatureFlagEntry> = {};
@@ -41,14 +79,17 @@ export const featureFlagsStore = create<FeatureFlagsState>()(
               flags[flag.Key] = { enabled: !!flag.Enabled, value: flag.Value ?? null };
             }
           }
-          set({ flags, isLoaded: true, error: null });
+          set({ flags, isLoaded: true, error: null, identityKey });
         } catch (error) {
-          // Keep any persisted flags on failure so gating stays stable while offline.
+          // Keep persisted flags on failure so gating stays stable while offline; the mismatch
+          // check above already cleared them if they belonged to a different identity. Marking
+          // isLoaded resolves flags with no persisted entry fail-closed (disabled) instead of
+          // leaving consumers waiting on 'unknown' forever.
           logger.error({
             message: 'Failed to fetch feature flags',
             context: { error },
           });
-          set({ error: error instanceof Error ? error.message : 'Failed to fetch feature flags' });
+          set({ error: error instanceof Error ? error.message : 'Failed to fetch feature flags', isLoaded: true });
         }
       },
       isEnabled: (key: string, defaultValue = false) => get().flags[key]?.enabled ?? defaultValue,
@@ -60,8 +101,28 @@ export const featureFlagsStore = create<FeatureFlagsState>()(
   )
 );
 
+// Logout clears MMKV but not in-memory zustand state; reset here so the next session starts
+// unknown and fails closed until fetchFlags resolves, instead of gating on the old identity's flags.
+registerStoreReset('feature-flags', () => featureFlagsStore.setState({ flags: {}, isLoaded: false, error: null, identityKey: null }));
+
 // Reactive hook; components re-render when the flag changes. Unknown flags default to disabled
 // so gated features stay hidden until the server confirms them.
 export const useFeatureFlag = (key: string, defaultValue = false) => featureFlagsStore((state) => state.flags[key]?.enabled ?? defaultValue);
 
 export const useIsChatEnabled = () => useFeatureFlag(FeatureFlagKeys.ChatSystem);
+
+export type FeatureFlagStatus = 'unknown' | 'enabled' | 'disabled';
+
+// Tri-state hook for gating that must not act before flags resolve (e.g. redirecting away
+// from a deep link). 'unknown' until flags for this identity are fetched or rehydrated;
+// fetch failures resolve fail-closed as 'disabled' for flags with no persisted entry.
+export const useFeatureFlagStatus = (key: string): FeatureFlagStatus =>
+  featureFlagsStore((state) => {
+    const entry = state.flags[key];
+    if (entry) {
+      return entry.enabled ? 'enabled' : 'disabled';
+    }
+    return state.isLoaded ? 'disabled' : 'unknown';
+  });
+
+export const useChatSystemStatus = (): FeatureFlagStatus => useFeatureFlagStatus(FeatureFlagKeys.ChatSystem);

--- a/src/stores/signalr/signalr-store.ts
+++ b/src/stores/signalr/signalr-store.ts
@@ -7,6 +7,7 @@ import { signalRService } from '@/services/signalr.service';
 
 import { useCoreStore } from '../app/core-store';
 import { useChatStore } from '../chat/store';
+import { FeatureFlagKeys, featureFlagsStore } from '../feature-flags/store';
 import { securityStore, useSecurityStore } from '../security/store';
 import { useWeatherAlertsStore } from '../weather-alerts/weather-alerts-store';
 
@@ -418,6 +419,14 @@ export const useSignalRStore = create<SignalRState>((set, get) => {
     },
     connectChatHub: async () => {
       try {
+        // Guard here so every call path (init, app-resume reconnect) honors the flag.
+        if (!featureFlagsStore.getState().isEnabled(FeatureFlagKeys.ChatSystem)) {
+          logger.info({
+            message: 'Chat disabled by feature flag; skipping chat hub connection',
+          });
+          return;
+        }
+
         if (get().isChatHubConnected) {
           return;
         }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This PR introduces a feature flag system and uses it to gate the entire chat feature behind a per-department `Chat.System` feature flag.

### What changed

**Feature flag infrastructure (new):**
- Added an API client (`src/api/feature-flags/feature-flags.ts`) that talks to the v4 `FeatureToggles` API, supporting fetching all department-scoped flags and checking individual flag state.
- Added a persisted Zustand store (`src/stores/feature-flags/store.ts`) that caches feature flags, survives offline failures using previously persisted values, and exposes reactive hooks (`useFeatureFlag`, `useIsChatEnabled`). Unknown flags default to disabled so gated features stay hidden until the server confirms them.

**Chat gating:**
- App initialization now fetches feature flags before connecting the SignalR chat hub. The hub connection is only established when `Chat.System` is enabled.
- The side menu filters out the **Chat** and **Assistant** items when the flag is off.
- All chat screens (chat list, chatbot/assistant, channel conversation, and thread view) now check `useIsChatEnabled()` and redirect to the home screen if chat is disabled. This also blocks deep links (e.g., from push notifications or stale routes) from accessing chat surfaces.

### Functional impact
Departments without the `Chat.System` flag enabled will see no chat functionality—no menu entries, no chatbot, no hub connections, and no access via direct navigation or deep links. Departments with the flag enabled are unaffected.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added feature-flag support for controlling chat and assistant availability.
  - Chat navigation and screens now appear and function only when enabled.
  - Added loading states while availability is being determined.
  - Disabled chat links redirect to the app home screen.
  - Chat connections are skipped when chat is unavailable.

- **Bug Fixes**
  - Prevented chat data and threads from loading when chat is disabled.
  - Added safe handling for feature-flag loading failures and account changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->