### PR TITLE
RG-T117 Chatbot fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "expo-audio": "~56.0.13",
     "expo-auth-session": "~56.0.16",
     "expo-build-properties": "~56.0.24",
+    "expo-clipboard": "~56.0.4",
     "expo-constants": "~56.0.22",
     "expo-crypto": "~56.0.4",
     "expo-dev-client": "~56.0.24",

--- a/src/api/chat/chatbot.ts
+++ b/src/api/chat/chatbot.ts
@@ -7,7 +7,7 @@ const CHATBOT = '/Chatbot';
 /** Gets (creating if needed) the caller's chatbot conversation channel. */
 export const getChatbotChannel = async (signal?: AbortSignal) => {
   const response = await api.get<ChatbotChannelResponse>(`${CHATBOT}/GetChatChannel`, { signal });
-  return response.data;
+  return response.data?.Data ?? null;
 };
 
 /**
@@ -19,7 +19,7 @@ export const sendChatbotMessage = async (text: string, clientMessageId: string) 
     Text: text,
     ClientMessageId: clientMessageId,
   });
-  return response.data;
+  return response.data?.Data ?? null;
 };
 
 /** Resets the chatbot conversational session (message history is retained). */

--- a/src/app/(app)/chat.tsx
+++ b/src/app/(app)/chat.tsx
@@ -103,6 +103,13 @@ export default function ChatScreen() {
 
   const openChannel = useCallback(
     (channelId: string) => {
+      // The assistant conversation always opens in its dedicated restricted screen
+      // (text only, no reactions/threads/deletes) instead of the generic conversation.
+      const channel = useChatStore.getState().channels.find((c) => c.ChatChannelId === channelId);
+      if (channel?.ChannelType === ChatChannelType.Chatbot) {
+        router.push('/chatbot' as Href);
+        return;
+      }
       router.push(`/chat/${channelId}` as Href);
     },
     [router]

--- a/src/app/(app)/chatbot.tsx
+++ b/src/app/(app)/chatbot.tsx
@@ -4,9 +4,13 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Platform } from 'react-native';
 
+import { copyToClipboard } from '@/components/chat/chat-utils';
+import { MessageActionsSheet } from '@/components/chat/message-actions-sheet';
 import { MessageBubble } from '@/components/chat/message-bubble';
 import { TypingDots } from '@/components/chat/typing-indicator';
+import { Actionsheet, ActionsheetBackdrop, ActionsheetContent, ActionsheetDragIndicator, ActionsheetDragIndicatorWrapper } from '@/components/ui/actionsheet';
 import { Box } from '@/components/ui/box';
+import { Button, ButtonText } from '@/components/ui/button';
 import { Center } from '@/components/ui/center';
 import { FlatList } from '@/components/ui/flat-list';
 import { FocusAwareStatusBar } from '@/components/ui/focus-aware-status-bar';
@@ -16,11 +20,14 @@ import { KeyboardAvoidingView } from '@/components/ui/keyboard-avoiding-view';
 import { Pressable } from '@/components/ui/pressable';
 import { Spinner } from '@/components/ui/spinner';
 import { Text } from '@/components/ui/text';
+import { Textarea, TextareaInput } from '@/components/ui/textarea';
 import { VStack } from '@/components/ui/vstack';
 import { type ChatMessageResultData } from '@/models/v4/chat';
 import useAuthStore from '@/stores/auth/store';
 import { useChatStore } from '@/stores/chat/store';
 import { useChatSystemStatus } from '@/stores/feature-flags/store';
+import { securityStore } from '@/stores/security/store';
+import { useToastStore } from '@/stores/toast/store';
 
 export default function ChatbotScreen() {
   const { t } = useTranslation();
@@ -30,7 +37,11 @@ export default function ChatbotScreen() {
   const chatbotChannelId = useChatStore((s) => s.chatbotChannelId);
   const chatbotTyping = useChatStore((s) => s.chatbotTyping);
   const messages = useChatStore((s) => (chatbotChannelId ? s.messagesByChannel[chatbotChannelId] : undefined));
+  const isModerator = !!securityStore((s) => s.rights)?.IsAdmin;
   const [text, setText] = useState('');
+  const [actionsMessage, setActionsMessage] = useState<ChatMessageResultData | null>(null);
+  const [editMessage, setEditMessage] = useState<ChatMessageResultData | null>(null);
+  const [editText, setEditText] = useState('');
 
   useFocusEffect(
     useCallback(() => {
@@ -61,7 +72,7 @@ export default function ChatbotScreen() {
 
   const renderItem = useCallback(
     ({ item }: { item: ChatMessageResultData }) => (
-      <MessageBubble message={item} isOwn={!!item.SenderUserId && item.SenderUserId === currentUserId} showSender={false} currentUserId={currentUserId} onLongPress={() => undefined} onToggleReaction={() => undefined} />
+      <MessageBubble message={item} isOwn={!!item.SenderUserId && item.SenderUserId === currentUserId} showSender={false} currentUserId={currentUserId} onLongPress={setActionsMessage} onToggleReaction={() => undefined} />
     ),
     [currentUserId]
   );
@@ -140,6 +151,57 @@ export default function ChatbotScreen() {
           </Pressable>
         </HStack>
       </KeyboardAvoidingView>
+
+      {/* Restricted actions for assistant messages: copy, edit own, pin (moderator), flag. */}
+      <MessageActionsSheet
+        message={actionsMessage}
+        isOpen={actionsMessage !== null}
+        onClose={() => setActionsMessage(null)}
+        isOwn={!!actionsMessage?.SenderUserId && actionsMessage.SenderUserId === currentUserId}
+        isModerator={isModerator}
+        assistant
+        onReact={() => undefined}
+        onReply={() => undefined}
+        onCopy={async (m) => {
+          const ok = await copyToClipboard(m.Body ?? '');
+          useToastStore.getState().showToast(ok ? 'success' : 'info', ok ? t('chat.copied') : t('chat.copy_unavailable'));
+        }}
+        onEdit={(m) => {
+          setEditMessage(m);
+          setEditText(m.Body ?? '');
+        }}
+        onDelete={() => undefined}
+        onFlag={(m, reason) => useChatStore.getState().flagMessage(m.ChatMessageId, reason)}
+        onTogglePin={(m, pinned) => chatbotChannelId && useChatStore.getState().togglePin(m.ChatMessageId, chatbotChannelId, pinned)}
+        onModeratorDelete={() => undefined}
+      />
+
+      {/* Edit own message */}
+      <Actionsheet isOpen={editMessage !== null} onClose={() => setEditMessage(null)}>
+        <ActionsheetBackdrop />
+        <ActionsheetContent>
+          <ActionsheetDragIndicatorWrapper>
+            <ActionsheetDragIndicator />
+          </ActionsheetDragIndicatorWrapper>
+          <VStack className="w-full p-2" space="md">
+            <Text className="text-base font-semibold text-typography-900">{t('chat.edit_message')}</Text>
+            <Textarea>
+              <TextareaInput value={editText} onChangeText={setEditText} multiline />
+            </Textarea>
+            <Button
+              className="bg-primary-600"
+              onPress={() => {
+                if (editMessage && chatbotChannelId && editText.trim()) {
+                  void useChatStore.getState().editMessage(editMessage.ChatMessageId, chatbotChannelId, editText.trim());
+                }
+                setEditMessage(null);
+              }}
+            >
+              <ButtonText>{t('chat.save')}</ButtonText>
+            </Button>
+          </VStack>
+        </ActionsheetContent>
+      </Actionsheet>
     </Box>
   );
 }

--- a/src/app/chat/[channelId].tsx
+++ b/src/app/chat/[channelId].tsx
@@ -51,6 +51,7 @@ export default function ChannelConversationScreen() {
   const loading = useChatStore((s) => (channelId ? s.loadingMessagesByChannel[channelId] : false));
 
   const [gifOpen, setGifOpen] = useState(false);
+  const [resolveAttempted, setResolveAttempted] = useState(false);
   const [actionsMessage, setActionsMessage] = useState<ChatMessageResultData | null>(null);
   const [editMessage, setEditMessage] = useState<ChatMessageResultData | null>(null);
   const [editText, setEditText] = useState('');
@@ -60,14 +61,30 @@ export default function ChannelConversationScreen() {
 
   const isDm = channel?.ChannelType === ChatChannelType.DirectMessage;
   const showSender = !isDm;
+  const isChatbot = channel?.ChannelType === ChatChannelType.Chatbot;
+  // Deep links (push notifications, cold starts) can arrive before the channel
+  // list loads; the channel type is unknown until then. Treat a completed fetch
+  // with no match as resolved so unknown channels keep the generic screen.
+  const isResolved = !!channel || resolveAttempted;
 
   // Natural order (oldest first); FlashList v2 renders from the bottom.
   const ordered = useMemo(() => messages ?? [], [messages]);
 
-  // Mount: activate channel, join hub, load history and members.
+  // Resolve the channel identity for deep links before mounting the generic view.
+  useEffect(() => {
+    if (channel || resolveAttempted || !isChatEnabled) return;
+    void useChatStore
+      .getState()
+      .fetchChannels()
+      .finally(() => setResolveAttempted(true));
+  }, [channel, resolveAttempted, isChatEnabled]);
+
+  // Mount: activate channel, join hub, load history and members. Assistant
+  // conversations are handled by the dedicated chatbot screen — never join or
+  // load them here, and wait for unresolved deep links to identify first.
   useFocusEffect(
     useCallback(() => {
-      if (!channelId || !isChatEnabled) return;
+      if (!channelId || !isChatEnabled || !isResolved || isChatbot) return;
       const store = useChatStore.getState();
       store.setActiveChannel(channelId);
       void store.joinChannel(channelId);
@@ -76,7 +93,7 @@ export default function ChannelConversationScreen() {
       return () => {
         useChatStore.getState().setActiveChannel(null);
       };
-    }, [channelId, isChatEnabled])
+    }, [channelId, isChatEnabled, isResolved, isChatbot])
   );
 
   // Fetch presence for the channel members (for the header online dot).
@@ -96,10 +113,10 @@ export default function ChannelConversationScreen() {
 
   // Mark read whenever the newest message changes while viewing.
   useEffect(() => {
-    if (channelId && ordered.length > 0) {
+    if (channelId && isResolved && !isChatbot && ordered.length > 0) {
       void useChatStore.getState().markChannelRead(channelId);
     }
-  }, [channelId, ordered.length]);
+  }, [channelId, isResolved, isChatbot, ordered.length]);
 
   const otherOnline = useMemo(() => {
     if (!isDm) return false;
@@ -254,9 +271,20 @@ export default function ChannelConversationScreen() {
     return <Redirect href="/(app)/home" />;
   }
 
+  // Deep link to a channel that isn't loaded yet: wait for the channel list so
+  // assistant conversations never mount the full-featured view.
+  if (!isResolved) {
+    return (
+      <Box className="size-full flex-1 items-center justify-center bg-background-0">
+        <Stack.Screen options={{ title, headerShown: true, headerBackTitle: '' }} />
+        <Spinner />
+      </Box>
+    );
+  }
+
   // Assistant conversations always use the dedicated restricted screen (text only,
   // no reactions/threads/deletes) — catch deep links and stale routes here.
-  if (channel?.ChannelType === ChatChannelType.Chatbot) {
+  if (isChatbot) {
     return <Redirect href={'/chatbot' as Href} />;
   }
 

--- a/src/app/chat/[channelId].tsx
+++ b/src/app/chat/[channelId].tsx
@@ -254,6 +254,12 @@ export default function ChannelConversationScreen() {
     return <Redirect href="/(app)/home" />;
   }
 
+  // Assistant conversations always use the dedicated restricted screen (text only,
+  // no reactions/threads/deletes) — catch deep links and stale routes here.
+  if (channel?.ChannelType === ChatChannelType.Chatbot) {
+    return <Redirect href={'/chatbot' as Href} />;
+  }
+
   return (
     <Box className="size-full flex-1 bg-background-0">
       <Stack.Screen

--- a/src/app/chat/thread/[messageId].tsx
+++ b/src/app/chat/thread/[messageId].tsx
@@ -135,7 +135,7 @@ export default function ThreadScreen() {
           contentContainerStyle={{ paddingVertical: 8 }}
         />
 
-        <MessageComposer onSendText={handleSendText} onSendImage={() => undefined} onSendLocation={handleSendLocation} onOpenGif={handleSendGif} onTyping={() => undefined} placeholder={t('chat.reply_placeholder')} />
+        <MessageComposer onSendText={handleSendText} onSendImage={() => undefined} onSendLocation={handleSendLocation} onOpenGif={handleSendGif} onTyping={() => undefined} placeholder={t('chat.reply_placeholder')} allowUrgent={false} />
       </KeyboardAvoidingView>
     </Box>
   );

--- a/src/components/chat/__tests__/chat-utils.test.ts
+++ b/src/components/chat/__tests__/chat-utils.test.ts
@@ -1,8 +1,13 @@
+import * as Clipboard from 'expo-clipboard';
 import { type TFunction } from 'i18next';
 
 import { ChatChannelType, type ChatChannelResultData } from '@/models/v4/chat';
 
-import { getChannelDisplayName, getImageMimeType, hasLink, linkifySegments } from '../chat-utils';
+import { copyToClipboard, getChannelDisplayName, getImageMimeType, hasLink, linkifySegments } from '../chat-utils';
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
 
 const mockT = ((key: string) => key) as TFunction;
 
@@ -71,6 +76,56 @@ describe('chat-utils', () => {
       expect(hasLink(null)).toBe(false);
       expect(hasLink('')).toBe(false);
       expect(hasLink('no links here')).toBe(false);
+    });
+  });
+
+  describe('copyToClipboard', () => {
+    const globalWithNavigator = globalThis as unknown as { navigator?: { clipboard?: { writeText?: (value: string) => Promise<void> } } };
+    let originalNavigator: unknown;
+
+    beforeEach(() => {
+      originalNavigator = globalWithNavigator.navigator;
+      jest.mocked(Clipboard.setStringAsync).mockReset();
+    });
+
+    afterEach(() => {
+      if (originalNavigator === undefined) {
+        delete globalWithNavigator.navigator;
+      } else {
+        globalWithNavigator.navigator = originalNavigator as typeof globalWithNavigator.navigator;
+      }
+    });
+
+    it('uses the web clipboard API when available', async () => {
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      globalWithNavigator.navigator = { clipboard: { writeText } };
+
+      await expect(copyToClipboard('hello')).resolves.toBe(true);
+      expect(writeText).toHaveBeenCalledWith('hello');
+      expect(Clipboard.setStringAsync).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the native module when the web API is unavailable', async () => {
+      delete globalWithNavigator.navigator;
+      jest.mocked(Clipboard.setStringAsync).mockResolvedValue(true);
+
+      await expect(copyToClipboard('hello')).resolves.toBe(true);
+      expect(Clipboard.setStringAsync).toHaveBeenCalledWith('hello');
+    });
+
+    it('falls back to the native module when the web API write fails', async () => {
+      globalWithNavigator.navigator = { clipboard: { writeText: jest.fn().mockRejectedValue(new Error('denied')) } };
+      jest.mocked(Clipboard.setStringAsync).mockResolvedValue(true);
+
+      await expect(copyToClipboard('hello')).resolves.toBe(true);
+      expect(Clipboard.setStringAsync).toHaveBeenCalledWith('hello');
+    });
+
+    it('returns false when the native write fails', async () => {
+      delete globalWithNavigator.navigator;
+      jest.mocked(Clipboard.setStringAsync).mockRejectedValue(new Error('unavailable'));
+
+      await expect(copyToClipboard('hello')).resolves.toBe(false);
     });
   });
 

--- a/src/components/chat/chat-utils.ts
+++ b/src/components/chat/chat-utils.ts
@@ -1,3 +1,4 @@
+import * as Clipboard from 'expo-clipboard';
 import { type TFunction } from 'i18next';
 
 import { getAvatarUrl } from '@/lib/utils';
@@ -105,9 +106,9 @@ export function hasLink(body?: string | null): boolean {
 }
 
 /**
- * Copies text to the clipboard. Works on web/Electron via the async Clipboard
- * API; native returns false (no clipboard native module is installed) so callers
- * can surface an appropriate message.
+ * Copies text to the clipboard. Uses the async Clipboard API on web/Electron
+ * and expo-clipboard on native; returns false only when both are unavailable
+ * or the write fails, so callers can surface an appropriate message.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
   try {
@@ -117,9 +118,13 @@ export async function copyToClipboard(text: string): Promise<boolean> {
       return true;
     }
   } catch {
-    // ignore and fall through
+    // ignore and fall through to the native module
   }
-  return false;
+  try {
+    return await Clipboard.setStringAsync(text);
+  } catch {
+    return false;
+  }
 }
 
 const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {

--- a/src/components/chat/message-actions-sheet.tsx
+++ b/src/components/chat/message-actions-sheet.tsx
@@ -16,6 +16,8 @@ interface MessageActionsSheetProps {
   onClose: () => void;
   isOwn: boolean;
   isModerator: boolean;
+  /** Assistant conversations: no reactions, threads or deletes — copy, edit own, pin and flag stay. */
+  assistant?: boolean;
   onReact: (message: ChatMessageResultData, emoji: string) => void;
   onReply: (message: ChatMessageResultData) => void;
   onCopy: (message: ChatMessageResultData) => void;
@@ -26,7 +28,7 @@ interface MessageActionsSheetProps {
   onModeratorDelete: (message: ChatMessageResultData) => void;
 }
 
-export function MessageActionsSheet({ message, isOpen, onClose, isOwn, isModerator, onReact, onReply, onCopy, onEdit, onDelete, onFlag, onTogglePin, onModeratorDelete }: MessageActionsSheetProps) {
+export function MessageActionsSheet({ message, isOpen, onClose, isOwn, isModerator, assistant = false, onReact, onReply, onCopy, onEdit, onDelete, onFlag, onTogglePin, onModeratorDelete }: MessageActionsSheetProps) {
   const { t } = useTranslation();
   const [mode, setMode] = useState<'actions' | 'flag'>('actions');
 
@@ -75,7 +77,7 @@ export function MessageActionsSheet({ message, isOpen, onClose, isOwn, isModerat
           </>
         ) : (
           <>
-            {!isDeleted ? (
+            {!isDeleted && !assistant ? (
               <HStack className="w-full justify-around px-2 py-3" space="sm">
                 {QUICK_REACTIONS.map((emoji) => (
                   <Pressable
@@ -92,15 +94,17 @@ export function MessageActionsSheet({ message, isOpen, onClose, isOwn, isModerat
               </HStack>
             ) : null}
 
-            <ActionsheetItem
-              onPress={() => {
-                onReply(message);
-                close();
-              }}
-            >
-              <MessageSquare size={18} color="#6b7280" />
-              <ActionsheetItemText>{t('chat.reply_in_thread')}</ActionsheetItemText>
-            </ActionsheetItem>
+            {!assistant ? (
+              <ActionsheetItem
+                onPress={() => {
+                  onReply(message);
+                  close();
+                }}
+              >
+                <MessageSquare size={18} color="#6b7280" />
+                <ActionsheetItemText>{t('chat.reply_in_thread')}</ActionsheetItemText>
+              </ActionsheetItem>
+            ) : null}
 
             {isText && !isDeleted ? (
               <ActionsheetItem
@@ -126,7 +130,7 @@ export function MessageActionsSheet({ message, isOpen, onClose, isOwn, isModerat
               </ActionsheetItem>
             ) : null}
 
-            {isOwn && !isDeleted ? (
+            {isOwn && !isDeleted && !assistant ? (
               <ActionsheetItem
                 onPress={() => {
                   onDelete(message);
@@ -157,7 +161,7 @@ export function MessageActionsSheet({ message, isOpen, onClose, isOwn, isModerat
               </ActionsheetItem>
             ) : null}
 
-            {isModerator && !isDeleted ? (
+            {isModerator && !isDeleted && !assistant ? (
               <ActionsheetItem
                 onPress={() => {
                   onModeratorDelete(message);

--- a/src/components/chat/message-composer.tsx
+++ b/src/components/chat/message-composer.tsx
@@ -25,9 +25,11 @@ interface MessageComposerProps {
   onTyping: (isTyping: boolean) => void;
   disabled?: boolean;
   placeholder?: string;
+  /** Urgent priority is channel-level only; thread replies pass false to hide the toggle. */
+  allowUrgent?: boolean;
 }
 
-export function MessageComposer({ onSendText, onSendImage, onSendLocation, onOpenGif, onTyping, disabled, placeholder }: MessageComposerProps) {
+export function MessageComposer({ onSendText, onSendImage, onSendLocation, onOpenGif, onTyping, disabled, placeholder, allowUrgent = true }: MessageComposerProps) {
   const { t } = useTranslation();
   const [text, setText] = useState('');
   const [urgent, setUrgent] = useState(false);
@@ -132,16 +134,18 @@ export function MessageComposer({ onSendText, onSendImage, onSendLocation, onOpe
         <Pressable className="p-2" onPress={handleShareLocation} disabled={disabled} accessibilityLabel={t('chat.share_location')}>
           <MapPin size={22} color="#6b7280" />
         </Pressable>
-        <Pressable className="p-2" onPress={() => setUrgent((prev) => !prev)} disabled={disabled} accessibilityLabel={t('chat.urgent')}>
-          <AlertTriangle size={22} color={urgent ? '#dc2626' : '#6b7280'} />
-        </Pressable>
+        {allowUrgent ? (
+          <Pressable className="p-2" onPress={() => setUrgent((prev) => !prev)} disabled={disabled} accessibilityLabel={t('chat.urgent')}>
+            <AlertTriangle size={22} color={urgent ? '#dc2626' : '#6b7280'} />
+          </Pressable>
+        ) : null}
 
         <Pressable className={`rounded-full p-2 ${text.trim() ? 'bg-primary-600' : 'bg-background-300'}`} onPress={handleSend} disabled={!text.trim() || disabled} accessibilityLabel={t('chat.send')}>
           <Send size={20} color="#ffffff" />
         </Pressable>
       </HStack>
 
-      {urgent ? (
+      {allowUrgent && urgent ? (
         <HStack className="mt-1 items-center px-2" space="xs">
           <AlertTriangle size={12} color="#dc2626" />
           <Text className="text-xs text-error-600">{t('chat.urgent_will_send')}</Text>

--- a/src/models/v4/chat/chatbotModels.ts
+++ b/src/models/v4/chat/chatbotModels.ts
@@ -1,21 +1,29 @@
 /**
- * Chatbot (assistant) API response shapes. Unlike the Chat controller, the
- * Chatbot web-chat endpoints return plain objects (not the { Data } envelope).
+ * Chatbot (assistant) API response shapes. Like the Chat controller, the chatbot
+ * web-chat endpoints wrap their payload in the standard v4 { Data } envelope.
  */
 
-export interface ChatbotChannelResponse {
+export interface ChatbotChannelData {
   ChatChannelId: string;
   Name?: string | null;
   LastMessageSeq: number;
   LastMessageOn?: string | null;
 }
 
-export interface ChatbotSendResponse {
+export interface ChatbotChannelResponse {
+  Data?: ChatbotChannelData | null;
+}
+
+export interface ChatbotSendData {
   ChatMessageId: string;
   MessageSeq: number;
   SentOn: string;
 }
 
+export interface ChatbotSendResponse {
+  Data?: ChatbotSendData | null;
+}
+
 export interface ChatbotSessionResponse {
-  success: boolean;
+  Success: boolean;
 }

--- a/src/stores/chat/store.ts
+++ b/src/stores/chat/store.ts
@@ -730,8 +730,10 @@ export const useChatStore = create<ChatState>()(
       },
 
       handleAckRequired: (raw: unknown) => {
-        const ack = parseEventData<ChatAckResultData>(raw);
+        const ack = parseEventData<ChatAckResultData & { SenderUserId?: string | null }>(raw);
         if (!ack || !ack.ChatMessageId) return;
+        // The sender never has to acknowledge their own urgent message.
+        if (ack.SenderUserId && ack.SenderUserId === currentUserId()) return;
         set((s) => (s.pendingAcks.some((a) => a.ChatMessageId === ack.ChatMessageId) ? {} : { pendingAcks: [...s.pendingAcks, ack] }));
       },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7359,6 +7359,11 @@ expo-build-properties@~56.0.24:
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
+expo-clipboard@~56.0.4:
+  version "56.0.4"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-56.0.4.tgz#b15ea42f4d0b149c76a34a19c899136e2049068e"
+  integrity sha512-qb4DYlkiowHYHaUYVT2FN9nk/nI1xShXOUYsI7J9dVpQCOHcGFjCBPX1VAvEW4Ye4/Aagd6IuhOVAq/+scBOiA==
+
 expo-constants@~56.0.22:
   version "56.0.22"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-56.0.22.tgz#df0c7bb02574801ea034d832c3baf5e862e50e19"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## PR Description

This PR fixes several issues with the chatbot (assistant) chat feature across API handling, routing, message actions, and urgent message acknowledgments.

### API Response Handling Fix
Corrected the chatbot API layer to properly unwrap the standard v4 `{ Data }` response envelope. The models were updated to reflect that chatbot endpoints wrap their payloads in `Data` (including capitalizing `Success` in the session response).

### Self-Acknowledgment Bug Fix
Fixed an issue where the sender of an urgent message was being prompted to acknowledge their own message. The acknowledgment handler now skips messages where the sender matches the current user.

### Chatbot Channel Routing
Ensured chatbot/assistant conversations always open in their dedicated restricted screen. Navigation from the channel list now detects chatbot channels and routes to `/chatbot`, and deep links or stale routes to the generic conversation screen for chatbot channels are redirected accordingly.

### Restricted Message Actions for Chatbot
Added long-press message actions to the chatbot screen, including copy, edit (own messages only), pin (moderator), and flag. A new `assistant` mode on the `MessageActionsSheet` hides reactions, thread replies, and deletes that aren't applicable to assistant conversations.

### Urgent Toggle Scoping
Hid the urgent priority toggle in thread reply composers, since urgent is a channel-level-only feature. Added an `allowUrgent` prop to the message composer to control this behavior.
<!-- kody-pr-summary:end -->