### PR TITLE
RR-T47 Style fix

### DIFF
--- a/src/components/ui/icon/index.tsx
+++ b/src/components/ui/icon/index.tsx
@@ -31,12 +31,15 @@ const iconStyle = tva({
 const StyledUIIcon = styled(UIIcon, {
   className: {
     target: 'style',
+    // Values must be prop paths, never `true`: react-native-css resolves each one with
+    // `path.split('.')`, so a boolean throws "undefined is not a function" the moment the class
+    // actually produces that style key — which for the size variants is every render.
     nativeStyleMapping: {
-      height: true,
-      width: true,
-      fill: true,
+      height: 'height',
+      width: 'width',
+      fill: 'fill',
       color: 'classNameColor',
-      stroke: true,
+      stroke: 'stroke',
     },
   },
 });

--- a/src/components/ui/spinner/index.tsx
+++ b/src/components/ui/spinner/index.tsx
@@ -5,7 +5,9 @@ import React from 'react';
 import { ActivityIndicator } from 'react-native';
 
 const StyledActivityIndicator = styled(ActivityIndicator, {
-  className: { target: 'style', nativeStyleMapping: { color: true } },
+  // A prop path, not `true`: react-native-css calls `.split('.')` on the value, so a boolean
+  // crashes as soon as the className resolves to a colour.
+  className: { target: 'style', nativeStyleMapping: { color: 'color' } },
 });
 
 const spinnerStyle = tva({});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes styling-related crashes in the shared `Icon` and `Spinner` UI components.

### What changed
- Updated the native style mapping for the `Icon` component so its `height`, `width`, `fill`, and `stroke` style values are mapped to explicit prop paths instead of boolean values.
- Updated the native style mapping for the `Spinner` component so its `color` style value is also mapped to an explicit prop path.

### Functional impact
- Prevents runtime errors caused when class-based styles are resolved for these components.
- Ensures icon sizing/color-related styles and spinner color styles can be applied correctly without breaking rendering.

### Why
The previous mappings used boolean values where the styling system expects prop path strings. When those styles were resolved, this caused failures during rendering.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling behavior for icons, including dimensions, fill, stroke, and color properties.
  * Improved spinner color handling for more consistent visual rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->